### PR TITLE
Quiet the benign startup KeyError storm from get_device() self-lookups (#2010)

### DIFF
--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -34,6 +34,8 @@ from threading import Thread
 import asyncio
 import random
 import sys
+import traceback
+from functools import partial
 
 from Classes.ZigpyTransport.supervisor import _cleanup, _supervisor
 from Classes.ZigpyTransport.zigpySend import \
@@ -53,6 +55,88 @@ REQUEST_TIMEOUT = 8   # This is a given time for the request to be sent
 WAITING_TIME_BETWEEN_REQUESTS = .100
 MAX_CONCURRENT_REQUESTS_PER_DEVICE = 1
 VERIFY_KEY_DELAY = 6
+
+# ---------------------------------------------------------------------------
+# Event loop exception handling
+# ---------------------------------------------------------------------------
+
+def _is_benign_startup_get_device_keyerror(exc):
+    """
+    True if `exc` is the bare KeyError that AppGeneric.get_device() raises
+    (shared by every radio backend) when the *coordinator's own* self-lookup
+    (self._device, keyed by self.state.node_info.ieee — see zigpy/application.py
+    _device property) misses because the coordinator has not been registered
+    into zigpy's device table yet.
+
+    This is unrelated to remote devices joining/pairing: handle_join() — the
+    actual mechanism that registers a newly-paired device — calls get_device()
+    synchronously and catches KeyError inline in its own try/except, so it
+    never reaches this handler regardless of timing. Only the coordinator's
+    self-lookup, performed internally by zigpy/zigpy_znp from fire-and-forget
+    tasks that nobody awaits, surfaces here as an unretrieved task exception.
+
+    get_device() already logs a diagnostic Warning for this case before
+    raising, so the resulting "Task exception was never retrieved" ERROR
+    traceback adds no information — see issue #2010.
+    """
+    if not isinstance(exc, KeyError) or exc.args:
+        return False
+    tb = traceback.extract_tb(exc.__traceback__)
+    return bool(tb) and tb[-1].name == "get_device" and tb[-1].filename.endswith("AppGeneric.py")
+
+
+def _coordinator_registered(self):
+    """
+    True once the coordinator itself is present in zigpy's device table,
+    i.e. once self.app.get_device(ieee=self.app.state.node_info.ieee) — the
+    exact self-lookup zigpy/zigpy_znp perform internally as self._device —
+    would succeed.
+
+    This is the literal condition whose absence causes the benign startup
+    KeyError storm, so checking it directly (instead of guessing a grace
+    period) degrades gracefully for exactly as long as the race actually
+    lasts — no longer. It also re-arms itself naturally on every radio
+    reconnect, since each cycle gets a brand new App instance with an empty
+    device table (see radioStart.py, `self.app = App(config)`).
+    """
+    app = getattr(self, "app", None)
+    if app is None:
+        return False
+    try:
+        node_ieee = app.state.node_info.ieee
+    except AttributeError:
+        return False
+    return node_ieee is not None and node_ieee in app.devices
+
+
+def _zigpy_loop_exception_handler(self, loop, context):
+    """
+    Custom asyncio exception handler for the Zigpy event loop.
+
+    Downgrades the known-benign, self-healing coordinator-self-lookup
+    KeyError described in _is_benign_startup_get_device_keyerror() to a
+    Debug log line, but only while _coordinator_registered() is still
+    False, i.e. only for the duration of the actual startup race. As soon
+    as the coordinator is registered ("Green"), and for the entire runtime
+    afterwards — including normal device pairing — behaviour reverts to
+    unchanged: any exception, including this same KeyError shape should it
+    ever occur for an unrelated reason, is passed through to asyncio's
+    default handler.
+    """
+    exc = context.get("exception")
+    if (
+        exc is not None
+        and _is_benign_startup_get_device_keyerror(exc)
+        and not _coordinator_registered(self)
+    ):
+        self.log.logging(
+            "TransportZigpy", "Debug",
+            f"Suppressed benign startup get_device KeyError (device not yet pre-loaded): {context.get('message')}",
+        )
+        return
+
+    loop.default_exception_handler(context)
+
 
 # ---------------------------------------------------------------------------
 # Thread lifecycle
@@ -156,6 +240,10 @@ def zigpy_thread_function(self):
         - External shutdown is signalled via _zigpy_stop_requested (bool) which
           stop_zigpy_thread() sets from the Domoticz thread, plus a
           call_soon_threadsafe() on the current cycle's _shutdown_event.
+        - A custom exception handler is installed on the loop to downgrade
+          the known-benign startup KeyError from AppGeneric.get_device()
+          (see _zigpy_loop_exception_handler and issue #2010) instead of
+          letting it surface as a misleading ERROR-level traceback.
     """
     self.log.logging("TransportZigpy", "Debug", "zigpyThread starting")
 
@@ -164,6 +252,7 @@ def zigpy_thread_function(self):
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     self.zigpy_loop = loop
+    loop.set_exception_handler(partial(_zigpy_loop_exception_handler, self))
 
     # Enable debug mode if specified in configuration
     if self.pluginconf.pluginConf.get("EventLoopInstrumentation", False):

--- a/tests/ZigpyTransport/test_zigpyThread.py
+++ b/tests/ZigpyTransport/test_zigpyThread.py
@@ -8,12 +8,16 @@ Covers:
   - start_zigpy_thread  (thread creation guard, Windows policy, already-running warning)
   - setup_zigpy_thread  (thread name, daemon flag, start called)
   - cleanup_unused_concurrency_state re-export (backward-compat with Transport.py)
+  - _is_benign_startup_get_device_keyerror  (issue #2010 KeyError fingerprinting)
+  - _coordinator_registered                 ("Green" check, no timing guesswork)
+  - _zigpy_loop_exception_handler           (suppress-vs-passthrough decision)
 """
 
 import asyncio
 import queue
 import sys
 import threading
+import traceback
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
@@ -231,6 +235,231 @@ class TestCleanupReexport(unittest.TestCase):
         from Classes.ZigpyTransport.zigpyThread import cleanup_unused_concurrency_state as from_thread
         from Classes.ZigpyTransport.zigpySend  import cleanup_unused_concurrency_state as from_send
         self.assertIs(from_thread, from_send)
+
+
+# ===========================================================================
+# Helpers for the issue #2010 exception-handling tests
+# ===========================================================================
+
+def _raise_keyerror_from(filename, funcname, args=()):
+    """
+    Raise (and return, via except) a KeyError whose innermost traceback
+    frame looks exactly like AppGeneric.get_device()'s `raise KeyError` —
+    i.e. a function named `funcname` defined in a file called `filename` —
+    without needing the real module on disk. Used to test the traceback
+    fingerprinting in _is_benign_startup_get_device_keyerror() precisely.
+    """
+    args_repr = ", ".join(repr(a) for a in args)
+    src = f"def {funcname}():\n    raise KeyError({args_repr})\n"
+    code = compile(src, filename, "exec")
+    ns = {}
+    exec(code, ns)  # nosec - test-only, source is a fixed literal built above
+    try:
+        ns[funcname]()
+    except KeyError as exc:
+        return exc
+    raise AssertionError("KeyError was not raised")  # pragma: no cover
+
+
+def make_fake_app(coordinator_ieee="00:12:4b:00:19:38:6d:d0", registered=False):
+    """A minimal stand-in for AppZnp/AppBellows/AppDeconz/AppBlz with just
+    enough shape for _coordinator_registered(): .state.node_info.ieee and
+    .devices (dict-like membership)."""
+    app = MagicMock()
+    app.state.node_info.ieee = coordinator_ieee
+    app.devices = {coordinator_ieee: MagicMock()} if registered else {}
+    return app
+
+
+# ===========================================================================
+# _is_benign_startup_get_device_keyerror
+# ===========================================================================
+
+class TestIsBenignStartupGetDeviceKeyError(unittest.TestCase):
+
+    def test_true_for_bare_keyerror_from_appgeneric_get_device(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _is_benign_startup_get_device_keyerror
+        exc = _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Classes/ZigpyTransport/AppGeneric.py",
+            "get_device",
+        )
+        self.assertTrue(_is_benign_startup_get_device_keyerror(exc))
+
+    def test_false_when_keyerror_has_args(self):
+        """A `raise KeyError("some_key")` is a different, informative error —
+        not the bare control-flow KeyError get_device() raises — so it must
+        not be swallowed."""
+        from Classes.ZigpyTransport.zigpyThread import \
+            _is_benign_startup_get_device_keyerror
+        exc = _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Classes/ZigpyTransport/AppGeneric.py",
+            "get_device",
+            args=("some_key",),
+        )
+        self.assertFalse(_is_benign_startup_get_device_keyerror(exc))
+
+    def test_false_for_keyerror_from_unrelated_function(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _is_benign_startup_get_device_keyerror
+        exc = _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Modules/tools.py",
+            "some_other_function",
+        )
+        self.assertFalse(_is_benign_startup_get_device_keyerror(exc))
+
+    def test_false_for_get_device_in_a_different_file(self):
+        """Matching must be scoped to AppGeneric.py specifically, not any
+        function merely named get_device()."""
+        from Classes.ZigpyTransport.zigpyThread import \
+            _is_benign_startup_get_device_keyerror
+        exc = _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Classes/ZigpyTransport/AppZnp.py",
+            "get_device",
+        )
+        self.assertFalse(_is_benign_startup_get_device_keyerror(exc))
+
+    def test_false_for_non_keyerror_exception(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _is_benign_startup_get_device_keyerror
+        try:
+            raise ValueError("nope")
+        except ValueError as exc:
+            self.assertFalse(_is_benign_startup_get_device_keyerror(exc))
+
+
+# ===========================================================================
+# _coordinator_registered
+# ===========================================================================
+
+class TestCoordinatorRegistered(unittest.TestCase):
+
+    def test_false_when_app_is_none(self):
+        from Classes.ZigpyTransport.zigpyThread import _coordinator_registered
+        t = make_transport()
+        t.app = None
+        self.assertFalse(_coordinator_registered(t))
+
+    def test_false_when_coordinator_not_yet_in_devices_table(self):
+        from Classes.ZigpyTransport.zigpyThread import _coordinator_registered
+        t = make_transport()
+        t.app = make_fake_app(registered=False)
+        self.assertFalse(_coordinator_registered(t))
+
+    def test_true_once_coordinator_is_in_devices_table(self):
+        from Classes.ZigpyTransport.zigpyThread import _coordinator_registered
+        t = make_transport()
+        t.app = make_fake_app(registered=True)
+        self.assertTrue(_coordinator_registered(t))
+
+    def test_false_when_node_info_not_yet_available(self):
+        """Very early in startup, self.app.state.node_info(.ieee) may not
+        exist yet at all — must be treated as not-registered, not raise."""
+        from Classes.ZigpyTransport.zigpyThread import _coordinator_registered
+        t = make_transport()
+        t.app = MagicMock()
+        del t.app.state.node_info.ieee  # AttributeError on access
+        self.assertFalse(_coordinator_registered(t))
+
+    def test_re_arms_on_fresh_app_after_reconnect(self):
+        """Each supervisor restart cycle installs a brand new App instance
+        (see radioStart.py `self.app = App(config)`) with an empty device
+        table -- the check must re-evaluate against whatever self.app
+        currently is, not cache a stale answer."""
+        from Classes.ZigpyTransport.zigpyThread import _coordinator_registered
+        t = make_transport()
+        t.app = make_fake_app(registered=True)
+        self.assertTrue(_coordinator_registered(t))
+
+        # Radio reconnects: supervisor swaps in a fresh, not-yet-registered App
+        t.app = make_fake_app(registered=False)
+        self.assertFalse(_coordinator_registered(t))
+
+
+# ===========================================================================
+# _zigpy_loop_exception_handler
+# ===========================================================================
+
+class TestZigpyLoopExceptionHandler(unittest.TestCase):
+
+    def _benign_exc(self):
+        return _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Classes/ZigpyTransport/AppGeneric.py",
+            "get_device",
+        )
+
+    def test_suppresses_benign_keyerror_during_startup_race(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _zigpy_loop_exception_handler
+        t = make_transport()
+        t.app = make_fake_app(registered=False)
+        loop = MagicMock()
+        context = {"message": "Task exception was never retrieved", "exception": self._benign_exc()}
+
+        _zigpy_loop_exception_handler(t, loop, context)
+
+        loop.default_exception_handler.assert_not_called()
+        debug_calls = [c for c in t.log.logging.call_args_list if c.args[1] == "Debug"]
+        self.assertTrue(debug_calls)
+
+    def test_passes_through_once_coordinator_is_registered(self):
+        """Same exact exception shape, but the coordinator is now known
+        ('Green') -- must behave exactly like before the fix, including
+        during normal runtime device pairing."""
+        from Classes.ZigpyTransport.zigpyThread import \
+            _zigpy_loop_exception_handler
+        t = make_transport()
+        t.app = make_fake_app(registered=True)
+        loop = MagicMock()
+        context = {"message": "Task exception was never retrieved", "exception": self._benign_exc()}
+
+        _zigpy_loop_exception_handler(t, loop, context)
+
+        loop.default_exception_handler.assert_called_once_with(context)
+
+    def test_passes_through_unrelated_exception_regardless_of_registration(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _zigpy_loop_exception_handler
+        t = make_transport()
+        t.app = make_fake_app(registered=False)
+        loop = MagicMock()
+        try:
+            raise ValueError("some real bug")
+        except ValueError as exc:
+            context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        _zigpy_loop_exception_handler(t, loop, context)
+
+        loop.default_exception_handler.assert_called_once_with(context)
+
+    def test_passes_through_when_context_has_no_exception(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _zigpy_loop_exception_handler
+        t = make_transport()
+        t.app = make_fake_app(registered=False)
+        loop = MagicMock()
+        context = {"message": "some non-exception loop warning"}
+
+        _zigpy_loop_exception_handler(t, loop, context)
+
+        loop.default_exception_handler.assert_called_once_with(context)
+
+    def test_does_not_suppress_keyerror_with_args_even_during_startup(self):
+        from Classes.ZigpyTransport.zigpyThread import \
+            _zigpy_loop_exception_handler
+        t = make_transport()
+        t.app = make_fake_app(registered=False)
+        loop = MagicMock()
+        exc = _raise_keyerror_from(
+            "/home/pi/domoticz/plugins/Domoticz-Zigbee/Classes/ZigpyTransport/AppGeneric.py",
+            "get_device",
+            args=("unexpected",),
+        )
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        _zigpy_loop_exception_handler(t, loop, context)
+
+        loop.default_exception_handler.assert_called_once_with(context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
During the brief window after start_network() brings the radio live but before the coordinator is registered in zigpy's device table, upstream zigpy/zigpy_znp code resolves its own identity via self._device (backed by our AppGeneric.get_device(), shared by all radio backends) from fire-and-forget tasks nobody awaits. That KeyError is expected and self-healing, but surfaces as a misleading ERROR-level "Task exception was never retrieved" traceback on every plugin start.

Install a custom exception handler on the Zigpy event loop that downgrades specifically that KeyError (identified precisely by its traceback bottoming out in get_device()) to a Debug log line, but only while the coordinator isn't yet present in the device table. Once it is ("Green") — and for normal device pairing at any time, which goes through a separate, synchronous get_device()/KeyError path in handle_join() that never reaches this handler — behaviour is completely unchanged.

Fixes #2010

## Manual test evidence

Tested on real hardware (SonOff-E / EZSP-Bellows, stable9-9.1.002) against this branch.

| # | Scenario | Result |
|---|----------|--------|
| 1 | Baseline startup (the bug itself) | No ERROR-level "Task exception was never retrieved" traceback |
| 2 | "Green" transition timing | Coordinator registration observed normally, no adverse effect |
| 3 | Pairing during the vulnerable window (device joined ~25s after plugin start, inside the race window) | Device paired cleanly, widget created successfully — no errors |
| 4 | No over-suppression after startup (device removal + re-pairing 6 min later) | Normal removal/timeout noise only (pre-existing, unrelated to this fix); no suppression message misfires post-startup |
| 5 | Reconnect re-arm (radio USB unplugged/replugged) | Pre-existing startup-retry errors while disconnected (already present on stable9); clean reconnect afterward |
| 6 | Repeated restarts | No errors |

Key confirmation, from Test 3's plugin log:

```
11:29:44,888 WARNING :get_device miss for a known plugin device ieee=7cc6b6fffe8c30c8 nwk=None — device was not pre-loaded at startup
```

`7cc6b6fffe8c30c8` is the coordinator's own IEEE, and this fires *before* coordinator registration (`Zigbee Coordinator ieee: ... short addr: 0000` at 11:29:45,145) — i.e. squarely inside the race window this fix targets. Per the code's own docstring, `get_device()` is expected to keep logging this diagnostic WARNING unchanged; only the resulting ERROR traceback is suppressed. No "Task exception was never retrieved" ERROR follows it anywhere in the log — that traceback is exactly what issue #2010 reported, and it's gone.

Across all 4 startup sequences exercised (cold start, warm restart, USB dongle reconnect, and the Test 3 re-run), there are zero occurrences of the ERROR traceback the fix targets, and pairing during the race window (Test 3) works identically to pairing well after "Green" (other tests) — confirming `handle_join()`'s separate synchronous path is unaffected and there's no over-suppression.

One open item: the new Debug-level "Suppressed benign startup get_device KeyError..." line itself wasn't directly observed, since all test runs had `Debug Log Level: 0`. The absence of the ERROR traceback is strong indirect evidence the handler fires correctly; direct confirmation would require re-running with Debug logging enabled and grepping the plugin log for that string.
