### PR TITLE
Fix TypeError: deque not JSON serializable in non-optimized-device-configuration REST API

### DIFF
--- a/Classes/WebServer/rest_NonOptimizedDevice.py
+++ b/Classes/WebServer/rest_NonOptimizedDevice.py
@@ -11,9 +11,18 @@
 # SPDX-License-Identifier:    GPL-3.0 license
 
 import json
+from collections import deque
 
 from Classes.WebServer.headerResponse import (prepResponseMessage,
                                               setupHeadersResponse)
+
+
+def _json_default(obj):
+    if isinstance(obj, (deque, set, frozenset)):
+        return list(obj)
+    if isinstance(obj, bytes):
+        return obj.hex()
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 
 # curl  http://127.0.0.1:9440/rest-zigate/1/non-optimized-device-configuration/xyxz
 
@@ -34,7 +43,7 @@ def non_optmize_device_configuration(self, verb, data, parameters):
 
     self.logging("Debug", f"rest_non_optimized_device_configuration requested on {parameters[0]}")
 
-    _response["Data"] = json.dumps(construct_configuration_file(self, parameters[0]))
+    _response["Data"] = json.dumps(construct_configuration_file(self, parameters[0]), default=_json_default)
     
     self.logging("Debug", f"rest_non_optimized_device_configuration response_data {_response['Data']}")
     return _response


### PR DESCRIPTION
Closing https://github.com/zigbeefordomoticz/z4d-certified-devices/issues/150#issuecomment-5225376077

The rest-zigate non-optimized-device-configuration endpoint embeds the raw device dict (rawInfos) in its JSON response. That dict can contain a RollingLQI deque (set in Modules/tools_sqn.py), which plain json.dumps cannot serialize, crashing the request. Add a default= handler that converts deque/set/frozenset to list and bytes to hex, mirroring the existing ZigbeeJSONEncoder used elsewhere in the WebServer.


