### PR TITLE
Guard topology poll against app being None during radio restart

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1138,7 +1138,11 @@ def retreive_zigpy_topology_data(self):
     # Determine sync period based on existing data
     if self.zigpy_topology is None:
         return
-    
+
+    if self.zigpy_topology.ControllerLink.app is None:
+        # Radio is mid-restart (supervisor recovering from a comms failure); nothing to poll yet
+        return
+
     if self.zigpy_topology.is_zigpy_topology_in_progress():
         # Scan in progress
         self.zigpy_topology.new_scan_detected = True


### PR DESCRIPTION
## Summary

  Fixes an unhandled AttributeError: 'NoneType' object has no attribute 'is_zigpy_topology_in_progress' seen in production logs on a  SLZB-6mu (EZSP/bellows) setup. When the zigpy supervisor restarts the transport after a comms failure (e.g. NcpFailure:  ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT), self.app is torn down and briefly None. onHeartbeat still fires during that window, and  retreive_zigpy_topology_data() in plugin.py reached into self.zigpy_topology.ControllerLink.app.is_zigpy_topology_in_progress() while  app was None, crashing the heartbeat. zigpy_request() already guards this exact case (if self.app is None: ... in  Classes/ZigpyTransport/zigpyThread.py); this applies the same guard to the topology poll path.

##  Scope

  - plugin.py — retreive_zigpy_topology_data(): added an early return when self.zigpy_topology.ControllerLink.app is None, alongside the  existing self.zigpy_topology is None check.
  - No changes to persistence formats, device database schema, or public behavior — this only skips a no-op poll during a transient  restart window instead of raising.
  - Single file, 5 insertions / 1 deletion.

##  Validation

  - python3 -m py_compile plugin.py — passes.
  - No existing unit test covers retreive_zigpy_topology_data() (no dedicated plugin.py test module in tests/), so this was verified by  code inspection and syntax check only, not exercised in an automated test.
  - Not yet verified against a live device reproducing the original restart cascade (SLZB-6mu comms loss → supervised restart → heartbeat  topology poll) — worth confirming in the field/next session where the original error was captured.