### PR TITLE
Upgrade zigpy radio backend libraries to latest versions

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,8 +1,8 @@
-zigpy==1.5.1
+zigpy==2.1.0
 zigpy_znp==1.1.0
-zigpy_deconz==0.25.5
+zigpy_deconz==1.0.0
 zigpy-blz==0.1.0
-bellows==0.49.0
+bellows==1.0.0
 pyserial>=3.5
 serialx>=1.4.0
 charset-normalizer==2.0.11


### PR DESCRIPTION
## Summary
- Bump the pinned zigpy radio backend libraries in `constraints.txt` to their latest releases: `zigpy` 1.5.1 → 2.1.0, `zigpy-deconz` 0.25.5 → 1.0.0, `bellows` 0.49.0 → 1.0.0 (`zigpy_znp` and `zigpy-blz` are unchanged).
- These are **major-version bumps** for two of the three libraries (zigpy 1.x→2.x, zigpy-deconz/bellows 0.x→1.0), so please smoke-test each affected radio backend (EZSP/Bellows, deCONZ) before merging — see risk notes below.

## What's changing per library

### `zigpy` 1.5.1 → 2.1.0
- **2.1.0**: Green Power types/frames/crypto parsing, KeepAlive cluster coordinator support, oversized-attribute-record handling changed from failing the request to a graceful path, extended final OTA image block timeout for slow devices, coordinator group-subscription API, Zigbee Direct Configuration cluster support.
- **2.0.1**: Fixed active-request tier counter decrementing; re-reads attributes that come back with "insufficient space" errors.
- **2.0.0**: OTA image caching per provider with combined index refresh; **quirks API moved out of zigpy core** (potentially relevant if any of our code imports zigpy quirks directly).
- **1.6.0**: aiohttp compatibility fixes for tests, better OTA provider de-duplication, cluster subclass attribute/command handling fixes, new `zigpy.radio` entry-point metadata for radio libraries.

### `zigpy-deconz` 0.25.5 → 1.0.0
- **1.0.0**: Adds support for the `APS_Encryption` transmit option (new capability, not obviously breaking on its own — first 1.0 release after a long 0.25.x line, so treat as a stability milestone rather than a rewrite).

### `bellows` 0.49.0 → 1.0.0
- **1.0.0**: Simplicity SDK 2025.12.3 support, fixes an "Event loop is closed" race in `EventLoopThread.force_stop`, EZSP v19 compatibility, `APS_Encryption` transmit option support, multicast group subscription API, combined XNCP unicast API.
- **0.49.2**: Fixed keyword arguments for `xncp_set_manual_source_route`.
- **0.49.1**: Extended startup reset wait to 2 seconds.

## Impact assessment on `Classes/ZigpyTransport`

`Classes/ZigpyTransport` doesn't just call the zigpy/bellows/deconz APIs — `AppGeneric.py` monkey-patches several `zigpy.application.ControllerApplication` lifecycle methods directly (`initialize`, `shutdown`, `watchdog_feed`, `connection_lost`, `get_device`, `handle_join`, `handle_leave`, `handle_relays`, `packet_received`, `_load_db`), and `App_bellows`/`App_deconz`/`App_znp`/`App_blz` in the sibling files subclass each radio's `ControllerApplication` directly. This is the part of the codebase most exposed to an upstream API change, since it relies on exact method signatures and internal attribute names rather than just calling public request/response APIs. I checked each override against what actually changed upstream:

- **`connection_lost()` (AppGeneric.py:436-499) — checked, safe.** This handler imports `bellows.ash.NcpFailure` and `bellows.types.named.NcpResetCode` inline to special-case an NCP ACK-timeout reset with a grace period after startup. I confirmed against the bellows 1.0.0 source that both `NcpFailure` (still `code: NcpResetCode` in `__init__`) and `NcpResetCode.ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT` (0x51) are unchanged in 1.0.0. If this ever did break, the existing `except ImportError` fallback degrades gracefully (loses the grace-period special case, falls through to the generic "Unexpected error type" branch) rather than crashing — but it isn't needed here.
- **`shutdown()` / `disconnect()` timeout wrapping (radioStart.py:100, supervisor.py:261/489, workerLoop.py:210) — likely to get *more* reliable, not less.** These call sites already wrap `self.app.disconnect()` / `self.app.shutdown()` in `asyncio.wait_for(..., timeout=5-10s)`, which reads like a defensive workaround for exactly the class of bug bellows 1.0.0's changelog calls out: *"Fix 'Event loop is closed' race in `EventLoopThread.force_stop`"*. Worth watching whether these timeouts still trip after the bump — if they stop tripping, our wrapper is now just redundant safety margin, not a required workaround.
- **`initialize()` (AppGeneric.py:212-335) — checked, safe.** Uses `self.state.network_info`, `self.backups.{create_backup,restore_backup,add_backup}`, `self.topology.start_periodic_scans()`, `self.load_network_info()`, `self.form_network()`, `self._get_effective_tx_power()`/`_get_effective_maximum_tx_power()`, and the plugin's own `CONF_WATCHDOG_ENABLED` / `CONF_TOPO_SCAN_ENABLED` / `CONF_TOPO_SCAN_PERIOD` / `CONF_NWK_VALIDATE_SETTINGS` / `CONF_NWK_BACKUP_ENABLED` config keys. I confirmed all five config keys are still defined with the same names in `zigpy/config/__init__.py` at 2.1.0. None of these are part of the OTA-caching or quirks-relocation changes that landed in 2.0.0.
- **zigpy 2.0.0's "quirks API moved out of zigpy core" and OTA image caching rework — not applicable.** `grep`ed the whole repo for `zigpy.ota` / `zigpy.quirks`: zero hits outside `Classes/LoggingManagement.py` and `Classes/PluginConf.py` (just log-category/config strings, not imports). `Classes/OTA.py` implements OTA entirely independently of `zigpy.ota`. So this relocation is a non-issue for us.
- **`AppBellows.py:100`** logs `self._ezsp.ezsp_version` at startup — worth checking this still reports sanely once EZSP v19 support lands with bellows 1.0.0, since firmware-version display/comparison logic elsewhere (`firmwareversionHelper.py`) depends on it.
- **New capabilities we don't yet use** (Green Power in zigpy 2.1.0, multicast group-subscription API and combined XNCP unicast API in bellows 1.0.0, `APS_Encryption` transmit option in both zigpy-deconz and bellows 1.0.0): none of these are referenced anywhere in `Classes/ZigpyTransport` today (`grep` for `xncp`, `multicast group`, `aps_encryption` came back empty in this dir), so they're pure additions with no migration needed — but they're candidates for future feature work once this bump is confirmed stable.

## Risk / test plan
- [ ] Start against a real ZNP coordinator and confirm pairing/attribute read/command flows still work (`zigpy_znp` itself is unchanged, but it runs on top of the bumped `zigpy` core).
- [ ] Start against an EZSP/Bellows (Silicon Labs) coordinator — bellows had the largest jump (0.49→1.0). Specifically watch the shutdown/restart path (`AppGeneric.shutdown`, `connection_lost`, the `asyncio.wait_for(self.app.disconnect(), ...)` call sites) for a full pairing → command → controlled restart cycle.
- [ ] Start against a deCONZ coordinator if available.
- [ ] Confirm `AppBellows.py`'s `self._ezsp.ezsp_version` log line still prints a sane value on an EZSP v19-capable stick.
- [ ] Confirm `pip install -r requirements.txt -c constraints.txt` resolves cleanly with no other pinned dependency conflicts.

## Files changed
- `constraints.txt` (3 lines changed)

## Commit included
- `2ecfff9c` — upgrading zigpy radio libs to latest version