### PR TITLE
Fix: send Default Response for Report Attributes (0x0A) commands

### DIFF
--- a/Zigbee/helperDefautResponse.py
+++ b/Zigbee/helperDefautResponse.py
@@ -31,7 +31,6 @@ response_required_commands = {
     0x0000: {
         0x00,  # Read Attributes
         0x02,  # Read Reporting Config
-        0x0A,  # Discover Attributes
         0x0C,  # Discover Commands Received
         0x0E,  # Discover Commands Generated
     },

--- a/tests/Zigbee/test_zigbee_default_response.py
+++ b/tests/Zigbee/test_zigbee_default_response.py
@@ -109,6 +109,22 @@ class TestMustSendDefaultResponse(unittest.TestCase):
         )
 
     # ------------------------------------------------------------
+    # Report Attributes (0x0A) has no dedicated response: unlike
+    # Read/Discover Attributes, it must fall back to a Default
+    # Response when the sender requests one (bit not set), otherwise
+    # the sender never gets acked and retransmits indefinitely.
+    # ------------------------------------------------------------
+    def test_report_attributes_requires_default_response(self):
+        self.assertTrue(
+            must_send_default_response(
+                frame_control=0x08,  # Disable Default Response bit NOT set
+                command_id=0x0A,     # Report Attributes
+                cluster_id=0x0000,
+                status=0x00
+            )
+        )
+
+    # ------------------------------------------------------------
     # Commands NOT in response-required table
     # ------------------------------------------------------------
     def test_unknown_cluster_default_response(self):


### PR DESCRIPTION
  ## Summary

  Fixes `must_send_default_response()` so a ZCL Default Response is correctly sent for Report Attributes (0x0A) frames, instead of being

  ---

  ## Why

  A user reported spurious/missing events from Zigbee remote switches (TS0041 buttons) after moving to Stable9 with Domoticz Extended enabled — real button clicks weren't showing up in Domoticz logs, and unexplained events appeared at other times.

  Their plugin log showed a TS011F plug retransmitting the exact same unacknowledged Report Attributes frame (SQN stuck at `0x63`) every  ~200ms, continuously, for the entire 13-hour log (227k+ repeats). `response_required_commands[0x0000]` listed `0x0A` as "Discover  Attributes" and suppressed the Default Response for it — but `0x0A` is actually **Report Attributes** (real Discover Attributes is `0x0C`,  already present separately). Report Attributes has no dedicated response of its own: when a sender clears the Disable Default Response bit,  it expects a plain Default Response ack. Never getting one, the device's stack retried indefinitely.

  That retry storm floods the coordinator's single serial link, which every device on the network shares — a very plausible explanation for  real button-press traffic from unrelated end devices getting delayed or dropped.

  ---

  ## Scope

  - `Zigbee/helperDefautResponse.py` — removed the incorrect `0x0A` entry from `response_required_commands[0x0000]`.
  - `tests/Zigbee/test_zigbee_default_response.py` — added a regression test.
  - No device-specific code touched; affects the generic ZCL default-response path for any device sending Report Attributes with Disable  Default Response cleared.

  ---

  ## Details

  `must_send_default_response()` falls back to "must send Default Response" (rule 4) for any command not found in a cluster's  `response_required_commands` set. `0x0A` was wrongly included there, so success-status Report Attributes frames were treated as if they had  their own dedicated response (like Read/Discover Attributes do) and were skipped. Removing the entry lets Report Attributes fall through to  the correct default-response behavior.

  ---

  ## Validation

  - Reproduced via a real user plugin log: `SrcNWK f9f8`, cluster `0000`, command `0a`, `FCF: 08` (Disable Default Response bit clear) —  `must_send_default_response` returned `False` every time, matching 227k+ unacked retransmissions of SQN `0x63` over 13 hours.
  - No live coordinator test performed as part of this PR; the fix is a targeted correction of a static lookup table.

  ---

  ## Unit Test Added

  Added `test_report_attributes_requires_default_response` to `tests/Zigbee/test_zigbee_default_response.py`, asserting  `must_send_default_response(frame_control=0x08, command_id=0x0A, cluster_id=0x0000, status=0x00)` returns `True`. All 12 tests in the file  pass.