### PR TITLE
Fix: drop spurious OnOff Report Attributes from Tuya remote buttons

### DIFF
--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -201,7 +201,10 @@ def Cluster0006(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             # Stateless Tuya button remotes report their real clicks via the manufacturer-specific
             # 0xFD/0xFC commands (see Decode8095), never through this attribute-report path. A plain
             # OnOff attribute report here is just the device's own idle heartbeat and carries no new
-            # information; forwarding it would force a spurious Domoticz widget update on every report.
+            # information. Normally this attribute is intercepted upstream by the generic ZCL-config
+            # path (Conf/ZclDefinitions/0006.json -> process_cluster_attribute_response(), the actual
+            # fix for this is there); this guard only matters if that generic path is ever bypassed
+            # (e.g. ZclDefinitions missing/misconfigured), so cluster-specific dispatch stays safe too.
             checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgClusterData)
             self.log.logging(
                 "Cluster",

--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -197,6 +197,20 @@ def Cluster0006(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgClusterData)
             return
 
+        if get_deviceconf_parameter_value(self, self.ListOfDevices[MsgSrcAddr]["Model"], "TUYA_REMOTE", return_default=None):
+            # Stateless Tuya button remotes report their real clicks via the manufacturer-specific
+            # 0xFD/0xFC commands (see Decode8095), never through this attribute-report path. A plain
+            # OnOff attribute report here is just the device's own idle heartbeat and carries no new
+            # information; forwarding it would force a spurious Domoticz widget update on every report.
+            checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgClusterData)
+            self.log.logging(
+                "Cluster",
+                "Debug",
+                "ReadCluster - ClusterId=0006 - dropping OnOff attribute report from Tuya remote %s/%s (Value: %s)" % (MsgSrcAddr, MsgSrcEp, MsgClusterData),
+                MsgSrcAddr,
+            )
+            return
+
         if self.ListOfDevices[MsgSrcAddr]["Model"] == "lumi.ctrl_neutral1" and MsgSrcEp != "02":
             checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgClusterData)
 

--- a/Modules/readZclClusters.py
+++ b/Modules/readZclClusters.py
@@ -20,7 +20,8 @@ from DevicesModules import FUNCTION_MODULE, FUNCTION_WITH_ACTIONS_MODULE
 from Modules.batterieManagement import UpdateBatteryAttribute
 from Modules.domoMaj import MajDomoDevice
 from Modules.tools import (checkAndStoreAttributeValue,
-                           get_device_config_param, getAttributeValue,
+                           get_device_config_param, get_deviceconf_parameter_value,
+                           getAttributeValue,
                            store_battery_percentage_time_stamp,
                            store_battery_voltage_time_stamp)
 from Modules.zclClusterHelpers import (decoding_attribute_data,
@@ -161,7 +162,24 @@ def process_cluster_attribute_response( self, Devices, MsgSQN, MsgSrcAddr, MsgSr
                 store_battery_voltage_time_stamp( self, MsgSrcAddr)
 
         elif data_action == UPDATE_DOMO_DEVICE and majdomodevice_possiblevalues( self, MsgSrcEp, MsgClusterId, MsgAttrID, device_model, value ):
-            action_majdomodevice( self, Devices, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, device_model, value )
+            if (
+                MsgClusterId == "0006"
+                and MsgAttrID == "0000"
+                and get_deviceconf_parameter_value(self, device_model, "TUYA_REMOTE", return_default=None)
+            ):
+                # Stateless Tuya button remotes (TS0041/TS0042/TS0043/TS0044/TS004F...) report their
+                # real clicks exclusively via the manufacturer-specific 0xFD/0xFC commands (handled in
+                # Decode8095), never via a plain OnOff attribute report. This report is just the
+                # device's own idle heartbeat and carries no new information; forwarding it would force
+                # a spurious Domoticz widget update (and re-fire any bound automation) on every report.
+                self.log.logging(
+                    "ZclClusters",
+                    "Debug",
+                    "process_cluster_attribute_response - dropping OnOff attribute report from Tuya remote %s/%s (Value: %s)" % (MsgSrcAddr, MsgSrcEp, value),
+                    nwkid=MsgSrcAddr,
+                )
+            else:
+                action_majdomodevice( self, Devices, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, device_model, value )
             
         elif data_action == STORE_SPECIFIC_ATTRIBUTE:
             _storage_specificlvl1 = cluster_attribute_retrieval( self, MsgSrcEp, MsgClusterId, MsgAttrID, STORE_SPECIFIC_PLACE_LVL1, model=device_model )

--- a/tests/Modules/test_readClusters_cluster0006.py
+++ b/tests/Modules/test_readClusters_cluster0006.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for Modules/readClusters.py:Cluster0006
+
+Coverage:
+  - TUYA_REMOTE-flagged devices (e.g. TS0041 and its siblings): a plain OnOff
+    (0x0006 attribute 0x0000) Report Attributes frame must NOT be forwarded to
+    MajDomoDevice. These devices report their real clicks exclusively via the
+    manufacturer-specific 0xFD/0xFC commands (see Z4D_decoders/z4d_decoder_
+    Remotes.py:Decode8095), which never go through Cluster0006 at all. A plain
+    attribute report from such a device is just an idle/heartbeat re-statement
+    of the resting state and previously forced a spurious Domoticz widget
+    update (and any dzVents "on device" automation) on every occurrence.
+  - Non-TUYA_REMOTE devices are unaffected: the OnOff attribute report is
+    still forwarded to MajDomoDevice as before (regression guard).
+"""
+
+import sys
+import types
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rc():
+    """Import Modules.readClusters with all external deps stubbed out."""
+    stubs = {
+        "Modules.domoMaj": _make_stub(
+            "Modules.domoMaj", MajDomoDevice=MagicMock(name="MajDomoDevice")
+        ),
+        "Modules.ikeaTradfri": _make_stub(
+            "Modules.ikeaTradfri", ikea_air_purifier_cluster=MagicMock(name="ikea_air_purifier_cluster")
+        ),
+        "Modules.lumi": _make_stub(
+            "Modules.lumi",
+            AqaraOppleDecoding0012=MagicMock(name="AqaraOppleDecoding0012"),
+            cube_decode=MagicMock(name="cube_decode"),
+            decode_vibr=MagicMock(name="decode_vibr"),
+            decode_vibrAngle=MagicMock(name="decode_vibrAngle"),
+        ),
+        "Modules.philips": _make_stub(
+            "Modules.philips", philips_dimmer_switch=MagicMock(name="philips_dimmer_switch")
+        ),
+        "Modules.readZclClusters": _make_stub(
+            "Modules.readZclClusters",
+            is_cluster_zcl_config_available=MagicMock(name="is_cluster_zcl_config_available", return_value=False),
+            process_cluster_attribute_response=MagicMock(name="process_cluster_attribute_response"),
+        ),
+        "Modules.schneider_wiser": _make_stub(
+            "Modules.schneider_wiser",
+            receiving_heatingdemand_attribute=MagicMock(name="receiving_heatingdemand_attribute"),
+            receiving_heatingpoint_attribute=MagicMock(name="receiving_heatingpoint_attribute"),
+        ),
+        "Modules.tools": _make_stub(
+            "Modules.tools",
+            DeviceExist=MagicMock(name="DeviceExist", return_value=True),
+            checkAndStoreAttributeValue=MagicMock(name="checkAndStoreAttributeValue"),
+            checkAttribute=MagicMock(name="checkAttribute"),
+            checkValidValue=MagicMock(name="checkValidValue", return_value=True),
+            get_deviceconf_parameter_value=MagicMock(name="get_deviceconf_parameter_value", return_value=None),
+            getEPforClusterType=MagicMock(name="getEPforClusterType", return_value=[]),
+            set_status_datastruct=MagicMock(name="set_status_datastruct"),
+            set_timestamp_datastruct=MagicMock(name="set_timestamp_datastruct"),
+        ),
+        "Modules.zclClusterHelpers": _make_stub(
+            "Modules.zclClusterHelpers", compute_metering_conso=MagicMock(name="compute_metering_conso")
+        ),
+        "Modules.zigateConsts": _make_stub("Modules.zigateConsts", ZONE_TYPE={}),
+    }
+
+    # Track "Modules.readClusters" itself too, so teardown restores whatever
+    # was cached before this fixture ran (e.g. a real module imported during
+    # collection) instead of evicting it and leaving downstream tests to
+    # re-import it against the (incomplete) global conftest stubs.
+    tracked = list(stubs) + ["Modules.readClusters"]
+    saved = {name: sys.modules.get(name) for name in tracked}
+    sys.modules.update(stubs)
+
+    sys.modules.pop("Modules.readClusters", None)
+    module = importlib.import_module("Modules.readClusters")
+
+    yield module
+
+    for name, old in saved.items():
+        if old is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = old
+
+
+def _plugin(model="TS0041"):
+    p = MagicMock()
+    p.log = MagicMock()
+    p.log.logging = MagicMock()
+    p.ListOfDevices = {"c4b2": {"Model": model}}
+    return p
+
+
+NWKID = "c4b2"
+EP = "01"
+CLUSTER = "0006"
+
+
+def test_tuya_remote_onoff_report_is_dropped(rc, monkeypatch):
+    """Regression: a TS0041-style plain OnOff heartbeat must not reach MajDomoDevice."""
+    monkeypatch.setattr(rc, "get_deviceconf_parameter_value", lambda *a, **kw: True)
+    maj_domo = MagicMock()
+    check_store = MagicMock()
+    monkeypatch.setattr(rc, "MajDomoDevice", maj_domo)
+    monkeypatch.setattr(rc, "checkAndStoreAttributeValue", check_store)
+
+    p = _plugin(model="TS0041")
+    rc.Cluster0006(p, {}, "01", NWKID, EP, CLUSTER, "0000", "10", "0001", "00", Source="8102")
+
+    maj_domo.assert_not_called()
+    check_store.assert_called_once_with(p, NWKID, EP, CLUSTER, "0000", "00")
+
+
+def test_non_tuya_remote_onoff_report_is_forwarded(rc, monkeypatch):
+    """Regression guard: ordinary OnOff devices keep forwarding to MajDomoDevice."""
+    monkeypatch.setattr(rc, "get_deviceconf_parameter_value", lambda *a, **kw: None)
+    maj_domo = MagicMock()
+    check_store = MagicMock()
+    monkeypatch.setattr(rc, "MajDomoDevice", maj_domo)
+    monkeypatch.setattr(rc, "checkAndStoreAttributeValue", check_store)
+
+    p = _plugin(model="TS011F-plug")
+    rc.Cluster0006(p, {}, "01", NWKID, EP, CLUSTER, "0000", "10", "0001", "00", Source="8102")
+
+    maj_domo.assert_called_once_with(p, {}, NWKID, EP, CLUSTER, "00")
+    check_store.assert_called_once_with(p, NWKID, EP, CLUSTER, "0000", "00")

--- a/tests/Modules/test_readZclClusters_tuya_remote_onoff.py
+++ b/tests/Modules/test_readZclClusters_tuya_remote_onoff.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for Modules/readZclClusters.py:process_cluster_attribute_response
+
+Coverage:
+  - TUYA_REMOTE-flagged devices (e.g. TS0041 and its siblings): a plain OnOff
+    (cluster 0x0006 attribute 0x0000) Report Attributes frame must NOT reach
+    action_majdomodevice()/MajDomoDevice(). This is the code path actually
+    taken in production for this traffic: Conf/ZclDefinitions/0006.json
+    declares attribute 0000 as a generic, always-enabled ZCL attribute with
+    ActionList ["check_store_value", "upd_domo_device"], so ReadCluster()'s
+    is_cluster_zcl_config_available() check routes every 0006/0000 message
+    through this function - never through readClusters.py:Cluster0006(),
+    regardless of device model.
+  - Non-TUYA_REMOTE devices are unaffected: the OnOff attribute report still
+    reaches action_majdomodevice() as before (regression guard).
+  - check_store_value still runs for TUYA_REMOTE devices (bookkeeping kept).
+"""
+
+import sys
+import types
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rzc():
+    """Import Modules.readZclClusters with all external deps stubbed out."""
+    stubs = {
+        "DevicesModules": _make_stub(
+            "DevicesModules", FUNCTION_MODULE={}, FUNCTION_WITH_ACTIONS_MODULE={}
+        ),
+        "Modules.batterieManagement": _make_stub(
+            "Modules.batterieManagement", UpdateBatteryAttribute=MagicMock(name="UpdateBatteryAttribute")
+        ),
+        "Modules.domoMaj": _make_stub(
+            "Modules.domoMaj", MajDomoDevice=MagicMock(name="MajDomoDevice")
+        ),
+        "Modules.tools": _make_stub(
+            "Modules.tools",
+            checkAndStoreAttributeValue=MagicMock(name="checkAndStoreAttributeValue"),
+            get_device_config_param=MagicMock(name="get_device_config_param", return_value=False),
+            get_deviceconf_parameter_value=MagicMock(name="get_deviceconf_parameter_value", return_value=None),
+            getAttributeValue=MagicMock(name="getAttributeValue"),
+            store_battery_percentage_time_stamp=MagicMock(name="store_battery_percentage_time_stamp"),
+            store_battery_voltage_time_stamp=MagicMock(name="store_battery_voltage_time_stamp"),
+        ),
+        "Modules.zclClusterHelpers": _make_stub(
+            "Modules.zclClusterHelpers",
+            decoding_attribute_data=MagicMock(name="decoding_attribute_data", return_value="00"),
+            handle_model_name=MagicMock(name="handle_model_name"),
+        ),
+    }
+
+    tracked = list(stubs) + ["Modules.readZclClusters"]
+    saved = {name: sys.modules.get(name) for name in tracked}
+    sys.modules.update(stubs)
+
+    sys.modules.pop("Modules.readZclClusters", None)
+    module = importlib.import_module("Modules.readZclClusters")
+
+    yield module
+
+    for name, old in saved.items():
+        if old is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = old
+
+
+ONOFF_CLUSTER_DEF = {
+    "Description": "On/Off",
+    "Version": "1",
+    "Attributes": {
+        "0000": {
+            "Enabled": True,
+            "Name": "OnOff",
+            "DataType": "10",
+            "Mandatory": True,
+            "ActionList": ["check_store_value", "upd_domo_device"],
+        }
+    },
+}
+
+
+def _plugin(model, tuya_remote):
+    p = MagicMock()
+    p.log = MagicMock()
+    p.log.logging = MagicMock()
+    p.pluginconf = MagicMock()
+    p.pluginconf.pluginConf = {"TrackingEraticValue": False, "trackZclClustersIn": False}
+    p.ListOfDevices = {NWKID: {"Model": model}}
+    p.DeviceConf = {model: {"Ep": {EP: {"0006": ""}}}}
+    if tuya_remote:
+        p.DeviceConf[model]["TUYA_REMOTE"] = True
+    p.readZclClusters = {"0006": ONOFF_CLUSTER_DEF}
+    return p
+
+
+NWKID = "c4b2"
+EP = "01"
+CLUSTER = "0006"
+ATTR_ONOFF = "0000"
+
+
+def test_tuya_remote_onoff_report_does_not_reach_majdomodevice(rzc, monkeypatch):
+    """Regression: a TS0041-style plain OnOff heartbeat must not drive a Domoticz update."""
+    maj_domo = MagicMock()
+    check_store = MagicMock()
+    get_devconf = MagicMock(side_effect=lambda self_, model, attr, return_default=None: True if attr == "TUYA_REMOTE" else return_default)
+    monkeypatch.setattr(rzc, "MajDomoDevice", maj_domo)
+    monkeypatch.setattr(rzc, "checkAndStoreAttributeValue", check_store)
+    monkeypatch.setattr(rzc, "get_deviceconf_parameter_value", get_devconf)
+
+    p = _plugin(model="TS0041", tuya_remote=True)
+    rzc.process_cluster_attribute_response(p, {}, "01", NWKID, EP, CLUSTER, ATTR_ONOFF, "10", "0001", "00", Source="8102")
+
+    maj_domo.assert_not_called()
+    check_store.assert_called_once_with(p, NWKID, EP, CLUSTER, ATTR_ONOFF, "00")
+
+
+def test_non_tuya_remote_onoff_report_reaches_majdomodevice(rzc, monkeypatch):
+    """Regression guard: ordinary OnOff devices keep driving MajDomoDevice as before."""
+    maj_domo = MagicMock()
+    check_store = MagicMock()
+    get_devconf = MagicMock(return_value=None)
+    monkeypatch.setattr(rzc, "MajDomoDevice", maj_domo)
+    monkeypatch.setattr(rzc, "checkAndStoreAttributeValue", check_store)
+    monkeypatch.setattr(rzc, "get_deviceconf_parameter_value", get_devconf)
+
+    p = _plugin(model="TS011F-plug", tuya_remote=False)
+    rzc.process_cluster_attribute_response(p, {}, "01", NWKID, EP, CLUSTER, ATTR_ONOFF, "10", "0001", "00", Source="8102")
+
+    maj_domo.assert_called_once()
+    args = maj_domo.call_args.args
+    assert args[1:5] == ({}, NWKID, EP, CLUSTER)
+    check_store.assert_called_once_with(p, NWKID, EP, CLUSTER, ATTR_ONOFF, "00")


### PR DESCRIPTION
## Summary

Stop forwarding the periodic, unsolicited OnOff `Report Attributes` (`0x0A`) heartbeat from Tuya stateless button remotes (`TUYA_REMOTE` certified devices, e.g. `TS0041`/`TS0042`/`TS0043`/`TS0044`/`TS004F`) to Domoticz — it was forcing a spurious widget update, and any user automation bound to it, on every occurrence.

**Update:** the first commit's guard (in `Cluster0006()`) turned out to be dead code for this exact traffic — see Details below. The second commit adds the guard at the code path actually exercised in production (`process_cluster_attribute_response()` in `Modules/readZclClusters.py`), which is where the real fix lives. The first commit's guard is kept as a defensive fallback and documented as such.

## Why

Investigating a user report ("unexpected event" repeatedly re-triggering a dzVents automation on a `Prise salon` plug), the plugin log for a `TS0041` button (`c4b2`) showed cluster `0x0006` traffic split as:

- **749×** `0x0A` Report Attributes, payload `00001000` (attribute `0000` OnOff = `00`/Off) — a plain idle heartbeat, `DisableDefaultRsp: 1` (device never expects an ack), spread over ~20h at roughly one every 1–2 min.
- **24×** `0xFD` — the device's real manufacturer-specific click command.

`TS0041.json`'s certified config declares `"ReadAttributes": {"0006": []}` — the plugin never polls this cluster for this device — so every one of those 749 `0x0A` frames is unsolicited.

Cross-checked against the two other major open-source Zigbee stacks — both reach the same conclusion for this exact device family:
- **zigbee-herdsman-converters** (`src/devices/tuya.ts`): `fromZigbee: [tuya.fz.on_off_action, fz.battery]` — `on_off_action` matches `type: "commandTuyaAction"` only; there is no converter wired up for a plain `attributeReport` on `genOnOff` for this model, so z2m silently drops it.
- **zha-quirks** (`zhaquirks/tuya/ts0041.py` → `TuyaSmartRemoteOnOffCluster`): registers `0xFD`/`0xFC` as manufacturer-specific commands and only emits a HA event from the cluster-specific command handler; the generic attribute-report handler is never overridden, so a plain OnOff report just updates zigpy's internal cache and never surfaces as a device event.

## Scope

- `Modules/readZclClusters.py:process_cluster_attribute_response()` — the actual fix.
- `Modules/readClusters.py:Cluster0006()` — same guard kept as a defensive fallback (see Details for why it doesn't fire in current configurations).
- Device-config-driven (keyed off the existing `TUYA_REMOTE` flag already present in certified configs), not a hardcoded model list.
- No radio-backend-specific code.
- Stacked on #2021 (`fix/report-attributes-default-response-stable9`) — base branch here is that branch, not `stable9` directly, so this PR's diff only shows the new change.

## Details

**Where this traffic actually goes.** `ReadCluster()` (`Modules/readClusters.py:172`) checks `is_cluster_zcl_config_available()` *before* ever consulting the `DECODE_CLUSTER` dispatch table that `Cluster0006()` lives in:

```python
if is_cluster_zcl_config_available(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, attribute=MsgAttrID):
    process_cluster_attribute_response(...)      # <- generic ZCL-config-driven path
elif MsgClusterId in DECODE_CLUSTER:
    _func(...)                                    # <- Cluster0006() only reached here
```

`Conf/ZclDefinitions/0006.json` (generic, model-agnostic ZCL cluster definitions, loaded unconditionally at startup via `load_zcl_cluster()`) declares attribute `0000` (OnOff) as `"Enabled": true` with `"ActionList": ["check_store_value", "upd_domo_device"]`. That makes `is_cluster_zcl_config_available()` return `True` for *every* `0006`/`0000` message on *every* device model, so it always routes through `process_cluster_attribute_response()` instead — never reaching `Cluster0006()`'s `MsgAttrID == "0000"` branch.

**The actual fix (2nd commit).** In `process_cluster_attribute_response()`'s action loop, right before the `UPDATE_DOMO_DEVICE` action invokes `action_majdomodevice()` (→ `MajDomoDevice()`), added a check: if the cluster/attribute is `0006`/`0000` and the device's certified config has `TUYA_REMOTE: true`, skip the Domoticz-driving action and log a debug line instead. `check_store_value` (bookkeeping, no Domoticz interaction) still runs unconditionally beforehand.

**1st commit's guard (kept, not the fix).** Same guard in `Cluster0006()`, now documented as a fallback for the (currently theoretical) case where the generic ZCL-config path is bypassed — e.g. a missing/misconfigured `ZclDefinitions` directory, in which case `is_cluster_zcl_config_available()` would return `False` and traffic would fall through to `Cluster0006()` as originally designed.

**Deliberately not touching Lumi/Aqara** `SwitchAQ2WithOff`/`SwitchAQ3WithOff` devices: for those, the cluster `0x0006` attribute report *is* the actual click-reporting mechanism (no separate manufacturer command carries it), so the same drop would risk eating real clicks. They don't set `TUYA_REMOTE` and are unaffected by this change either way.

The real click path (`0xFD`/`0xFC`, handled entirely in `Decode8095()` / `Z4D_decoders/z4d_decoder_Remotes.py`) never goes through either of these code paths, so this change cannot affect real click delivery.

## Validation

- Reproduced the exact log pattern against the fix logic with unit tests exercising `process_cluster_attribute_response()` directly (the real call site) and `Cluster0006()` (the fallback); confirmed `MajDomoDevice` is not called for a `TUYA_REMOTE`-flagged device's plain `0000` attribute report in either path, while it's still called for an ordinary OnOff device (regression guard).
- `pytest .`: 1321 passed (baseline before this branch: 1317 passed + 4 new tests across both test files; the one pre-existing failure, `test_domoticz_named_process_detected_even_without_db_handle`, is an unrelated flaky process-detection race, reproduces identically on the base branch).
- `flake8 . --builtins=Devices,Parameters,Connection --count --select=E9,F63,F7,F82`: 0.

## Unit Test Added

- `tests/Modules/test_readZclClusters_tuya_remote_onoff.py` (new, covers the actual fix):
  - `test_tuya_remote_onoff_report_does_not_reach_majdomodevice` — a `TS0041`-flagged device's plain OnOff attribute report must not reach `MajDomoDevice`, and `check_store_value` bookkeeping still runs.
  - `test_non_tuya_remote_onoff_report_reaches_majdomodevice` — regression guard: an ordinary (non-`TUYA_REMOTE`) device's OnOff attribute report still reaches `MajDomoDevice` exactly as before.
- `tests/Modules/test_readClusters_cluster0006.py` (covers the defensive fallback in `Cluster0006()`):
  - `test_tuya_remote_onoff_report_is_dropped` / `test_non_tuya_remote_onoff_report_is_forwarded` — same coverage, for the fallback code path.