### PR TITLE
Docs: stable9 is now the production/target branch, stable8 locked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Before writing or proposing any code change, verify ALL of the following:
 ### Environment
 - [ ] Python ≥ 3.11
 - [ ] Domoticz ≥ 2025.2
-- [ ] Target branch is `stable8` for production
+- [ ] Target branch is `stable9` for production
 
 ### Architecture
 - [ ] `plugin.py` remains thin (orchestration only)
@@ -145,9 +145,9 @@ Domoticz (host)
 
 ---
 
-## 🌿 stable8 Branch Discipline
+## 🌿 stable9 Branch Discipline
 
-`stable8` is the **production branch**. It must be:
+`stable9` is the **production branch**. `stable8` (and earlier: `stable7`, `stable6`) are out of support and locked — no changes target them. It must be:
 - Upgrade-safe
 - Backward compatible
 - Stable for critical automations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ plugin.py (entry point, ~2000 lines)
 ### From AGENTS.md (Must Follow)
 
 **Stability Requirements:**
-- No breaking changes to stable8 branch
+- No breaking changes to stable9 branch
 - Preserve long-term backward compatibility
 - No persistent data format changes without migration
 - Upgrades must remain safe
@@ -89,7 +89,7 @@ plugin.py (entry point, ~2000 lines)
 **Environment:**
 - Python >= 3.11
 - Domoticz >= 2025.2 (2025.1 minimum)
-- Target stable8 branch for production changes
+- Target stable9 branch for production changes
 
 ## Development Workflow
 
@@ -312,7 +312,7 @@ Each backend (ZNP, EZSP, deCONZ, BLZ) has:
 
 **Before Proposing Changes:**
 - Read and follow AGENTS.md (mandatory)
-- Ensure changes are backward compatible (stable8 requirement)
+- Ensure changes are backward compatible (stable9 requirement)
 - No blocking calls in Zigpy thread
 - Test with `pytest . && flake8 .`
 - Keep plugin.py thin; move logic to Modules/
@@ -348,6 +348,7 @@ Each backend (ZNP, EZSP, deCONZ, BLZ) has:
 
 ## Version & Branch Info
 
-- **stable8**: Recommended for production (version 8.1.xxx)
-- **stable7**: Out of support (version 7.1.xxx)
-- Current version: 8.1.005 (2026.4)
+- **stable9**: Recommended for production (version 9.1.xxx)
+- **stable8**: Out of support, locked (version 8.1.xxx)
+- **stable7**: Out of support, locked (version 7.1.xxx)
+- Current version: 9.1.002 (2026.8)

--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,9 @@ The community maintains a list of certified Zigbee Device Objects at [https://zi
 In theory, any Zigbee devices that fully comply with the Zigbee 3.0, Zigbee Home Automation, and Zigbee Light Link specifications set by the Zigbee Alliance should be technically compatible with this project. However, it's worth noting that certain hardware manufacturers may not consistently adhere to all the specified requirements, resulting in partial or non-functional device behavior without custom integrations. Nevertheless, developers often find solutions or workarounds for non-standard features to address these issues.
 
 ## Branches
-- **stable7**: out of support (version 7.1.xxx).
-- **stable8**: Recommended for production use (version 8.1.xxx).
+- **stable9**: Recommended for production use (version 9.1.xxx).
+- **stable8**: out of support, locked (version 8.1.xxx).
+- **stable7**: out of support, locked (version 7.1.xxx).
 
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
Update CLAUDE.md, AGENTS.md, and readme.md so stable9 is documented as the recommended production/target branch; stable8 is now out of support and locked, alongside stable7.

## Why
stable9 (9.1.002) has shipped and is now the branch new work should target, per maintainer direction. stable8's status changes from "recommended for production" to "out of support, locked" — same tier as stable7/stable6.

## Scope
Docs only: `CLAUDE.md`, `AGENTS.md`, `readme.md`. `ReleaseNotes.md` untouched (historical changelog, already lists stable9 as the latest entry).

## Details
- `AGENTS.md`: checklist target branch, "stable8 Branch Discipline" section retitled/reworded to stable9.
- `CLAUDE.md`: stability/target-branch references, "Version & Branch Info" section updated (stable9 recommended, stable8/stable7 locked, current version bumped to 9.1.002 (2026.8)).
- `readme.md`: "Branches" section updated with the same tiering.

## Validation
Docs-only change; `pytest .` and `flake8` unaffected (not re-run for this PR, no code touched).

## Unit Test Added
N/A — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)