### PR TITLE
Fix Unit.Update(): forward SuppressTriggers, persist properties

### DIFF
--- a/Modules/domoticzAbstractLayer.py
+++ b/Modules/domoticzAbstractLayer.py
@@ -618,7 +618,7 @@ def domo_update_api(self, Devices, DeviceID_, Unit_, nValue, sValue,
                              f"domo_update_api: Cannot write Options {Options}: {e}", nwkid)
 
     try:
-        unit_obj.Update(Log=(not SuppressTriggers))
+        unit_obj.Update(Log=True, SuppressTriggers=SuppressTriggers, UpdateProperties=True)
     except Exception as e:
         self.log.logging("AbstractDz", "Error",
                          f"domo_update_api - Unit.Update() raised: {e}", nwkid)
@@ -660,7 +660,7 @@ def domo_update_SwitchType_SubType_Type(self, Devices, DeviceID_, Unit_,
 
     if Typename_:
         try:
-            Devices[DeviceID_].Units[Unit_].Update(TypeName=Typename_)
+            Devices[DeviceID_].Units[Unit_].Update(TypeName=Typename_, UpdateProperties=True)
         except Exception as e:
             self.log.logging("AbstractDz", "Error",
                              f"domo_update_SwitchType_SubType_Type - Update() raised: {e}")

--- a/tests/Modules/test_domoticzAbstractLayer.py
+++ b/tests/Modules/test_domoticzAbstractLayer.py
@@ -67,8 +67,13 @@ class _FakeUnit:
         if self._parent_device is not None and self.Unit in self._parent_device.Units:
             del self._parent_device.Units[self.Unit]
 
-    def Update(self, Log=True, TypeName=None):
+    def Update(self, Log=True, TypeName=None, SuppressTriggers=False, UpdateProperties=False):
         self._updated = True
+        self._update_log = Log
+        self._update_suppress_triggers = SuppressTriggers
+        self._update_properties = UpdateProperties
+        if TypeName is not None and UpdateProperties:
+            self.TypeName = TypeName
 
     def Touch(self):
         self._touched = True
@@ -684,12 +689,21 @@ class TestDomoUpdateApi(unittest.TestCase):
         domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off", TimedOut=1)
         self.assertEqual(devices["ieee-1"].TimedOut, 1)
 
-    def test_suppress_triggers_passes_log_false(self):
+    def test_suppress_triggers_is_forwarded(self):
         obj = _make_self()
         devices = _make_devices(("ieee-1", [(1, {})]))
         domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off", SuppressTriggers=True)
-        # Update should still be called (just with Log=False)
-        self.assertTrue(devices["ieee-1"].Units[1]._updated)
+        unit = devices["ieee-1"].Units[1]
+        self.assertTrue(unit._updated)
+        self.assertTrue(unit._update_suppress_triggers)
+
+    def test_battery_level_update_sets_update_properties(self):
+        obj = _make_self()
+        devices = _make_devices(("ieee-1", [(1, {})]))
+        domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off", BatteryLevel=50)
+        unit = devices["ieee-1"].Units[1]
+        self.assertEqual(unit.BatteryLevel, 50)
+        self.assertTrue(unit._update_properties)
 
     def test_ieee2nwk_miss_does_not_raise(self):
         obj = _make_self()
@@ -720,6 +734,27 @@ class TestDomoUpdateName(unittest.TestCase):
     def test_missing_device_does_not_raise(self):
         obj = _make_self()
         domo.domo_update_name(obj, {}, "ghost", 1, "Name")
+
+
+class TestDomoUpdateSwitchTypeSubTypeType(unittest.TestCase):
+
+    def test_typename_update_sets_update_properties(self):
+        obj = _make_self()
+        devices = _make_devices(("ieee-1", [(1, {})]))
+        domo.domo_update_SwitchType_SubType_Type(obj, devices, "ieee-1", 1, Typename_="Switch")
+        unit = devices["ieee-1"].Units[1]
+        self.assertEqual(unit.TypeName, "Switch")
+        self.assertTrue(unit._update_properties)
+
+    def test_no_typename_does_not_update(self):
+        obj = _make_self()
+        devices = _make_devices(("ieee-1", [(1, {})]))
+        domo.domo_update_SwitchType_SubType_Type(obj, devices, "ieee-1", 1)
+        self.assertFalse(devices["ieee-1"].Units[1]._updated)
+
+    def test_missing_device_does_not_raise(self):
+        obj = _make_self()
+        domo.domo_update_SwitchType_SubType_Type(obj, {}, "ghost", 1, Typename_="Switch")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`Unit.Update()` calls in `domoticzAbstractLayer.py` were dropping two Domoticz plugin API arguments: `SuppressTriggers` was never actually forwarded, and `UpdateProperties` was never set, so several unit attributes silently failed to persist.

---

## Why

While investigating a `unit_obj.Update()` mistake, found that `domo_update_api()` computed `Log=(not SuppressTriggers)` instead of passing `SuppressTriggers` through — so callers requesting `SuppressTriggers=True` never actually suppressed triggers, they just (accidentally) disabled logging instead. Separately, per the DomoticzEx plugin framework, `Color`/`BatteryLevel`/`SignalLevel`/`Options` set directly on the unit object before `Update()` are only pushed to the DB when `UpdateProperties=True` is passed — which this function never did. The clearest victim: `update_battery_device_unit_api()` calls `domo_update_api(..., BatteryLevel=battery_level, SuppressTriggers=True)`, so battery-level updates were likely not persisting at all. `domo_update_SwitchType_SubType_Type()` had the same missing-`UpdateProperties` gap for `TypeName` changes.

---

## Scope

- `Modules/domoticzAbstractLayer.py` — `domo_update_api()`, `domo_update_SwitchType_SubType_Type()`
- Target branch: `stable9`
- No device-model or radio-backend specific code touched; affects the widget-update path used by all devices (most visibly battery-level reporting).

---

## Details

- `domo_update_api()`: `unit_obj.Update(Log=(not SuppressTriggers))` → `unit_obj.Update(Log=True, SuppressTriggers=SuppressTriggers, UpdateProperties=True)`.
- `domo_update_SwitchType_SubType_Type()`: `Update(TypeName=Typename_)` → `Update(TypeName=Typename_, UpdateProperties=True)`.
- Verified via `git log -p` on this file that the original pre-refactor code (before the DomoticzEx extended-API merge) called `Update(Log=True)` on this path and `Update(**params, SuppressTriggers=True)` on the legacy path — the merge collapsed both into the current buggy line.

---

## Validation

- Full suite: `pytest .` → 1321 passed.
- `flake8 . --builtins=Devices,Parameters,Connection --count --select=E9,F63,F7,F82` → clean.
- `bandit -r .` → no new findings (1 pre-existing low-severity, unrelated).
- No physical device available in this environment; validated at the abstraction-layer/unit-test level only. Recommend confirming battery-level widget updates persist correctly on a real device before merge.

---

## Unit Test Added

- `tests/Modules/test_domoticzAbstractLayer.py`:
  - Replaced `test_suppress_triggers_passes_log_false` (which asserted the old, buggy behavior) with `test_suppress_triggers_is_forwarded`, asserting `SuppressTriggers` reaches `Update()`.
  - Added `test_battery_level_update_sets_update_properties`, asserting `UpdateProperties=True` is passed when `BatteryLevel` changes.
  - Added `TestDomoUpdateSwitchTypeSubTypeType` (3 cases) covering the `UpdateProperties` fix for `TypeName` updates.
  - Extended the `_FakeUnit.Update()` test double to accept/record `SuppressTriggers` and `UpdateProperties` (previously only stubbed `Log`/`TypeName`).
