### PR TITLE
Fix domo_update_api: pass UpdateOptions=True so widget Options persist

### DIFF
--- a/Modules/domoticzAbstractLayer.py
+++ b/Modules/domoticzAbstractLayer.py
@@ -618,7 +618,7 @@ def domo_update_api(self, Devices, DeviceID_, Unit_, nValue, sValue,
                              f"domo_update_api: Cannot write Options {Options}: {e}", nwkid)
 
     try:
-        unit_obj.Update(Log=(not SuppressTriggers))
+        unit_obj.Update(Log=(not SuppressTriggers), UpdateOptions=(Options is not None))
     except Exception as e:
         self.log.logging("AbstractDz", "Error",
                          f"domo_update_api - Unit.Update() raised: {e}", nwkid)

--- a/tests/Modules/test_domoticzAbstractLayer.py
+++ b/tests/Modules/test_domoticzAbstractLayer.py
@@ -54,6 +54,7 @@ class _FakeUnit:
         self._deleted = False
         self._updated = False
         self._touched = False
+        self._last_update_kwargs = None
         # Back-reference set by _make_devices so Delete() can remove itself
         self._parent_device: "_FakeDevice | None" = None
 
@@ -67,8 +68,12 @@ class _FakeUnit:
         if self._parent_device is not None and self.Unit in self._parent_device.Units:
             del self._parent_device.Units[self.Unit]
 
-    def Update(self, Log=True, TypeName=None):
+    def Update(self, Log=True, TypeName=None, UpdateProperties=False, UpdateOptions=False, SuppressTriggers=False):
         self._updated = True
+        self._last_update_kwargs = {
+            "Log": Log, "TypeName": TypeName, "UpdateProperties": UpdateProperties,
+            "UpdateOptions": UpdateOptions, "SuppressTriggers": SuppressTriggers,
+        }
 
     def Touch(self):
         self._touched = True
@@ -697,6 +702,21 @@ class TestDomoUpdateApi(unittest.TestCase):
         devices = _make_devices(("ieee-1", [(1, {})]))
         # Should not raise KeyError
         domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off")
+
+    def test_options_triggers_updateoptions_flag(self):
+        obj = _make_self()
+        devices = _make_devices(("ieee-1", [(1, {})]))
+        domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off", Options={"EnergyMeterMode": "1"})
+        unit = devices["ieee-1"].Units[1]
+        self.assertEqual(unit.Options, {"EnergyMeterMode": "1"})
+        self.assertTrue(unit._last_update_kwargs["UpdateOptions"])
+
+    def test_no_options_does_not_set_updateoptions_flag(self):
+        obj = _make_self()
+        devices = _make_devices(("ieee-1", [(1, {})]))
+        domo.domo_update_api(obj, devices, "ieee-1", 1, 0, "Off")
+        unit = devices["ieee-1"].Units[1]
+        self.assertFalse(unit._last_update_kwargs["UpdateOptions"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`domo_update_api()` sets a widget's `Options` attribute but never persists it to the database, because it doesn't pass `UpdateOptions=True` to `Unit.Update()`.

---

## Why

Fixes #2026. Confirmed directly against the upstream `CUnitEx_update()` implementation (`domoticz/domoticz`, `hardware/plugins/PythonObjectEx.cpp`): the entire Options-write block (`m_sql.SetDeviceOptions(...)` / the `SubType == sTypeCustom` fallback) is gated behind `if (bUpdateOptions)`, which is only set when the `UpdateOptions` keyword is passed to `Update()`. `domo_update_api()` never passes it, so any caller relying on it to persist Options gets silently dropped. Real victim: `Modules/domoMaj.py`'s `check_set_meter_widget()` uses this exact path to persist a power meter's `EnergyMeterMode` Option — that write was never actually reaching the DB.

---

## Scope

- `Modules/domoticzAbstractLayer.py` — `domo_update_api()`
- `tests/Modules/test_domoticzAbstractLayer.py` — fake `Unit.Update()` + new coverage
- Target branch: `stable9`

---

## Details

Added `UpdateOptions=(Options is not None)` to the existing `unit_obj.Update(...)` call in `domo_update_api()`. This is a minimal, targeted change — it does not touch the separate known `SuppressTriggers`/`UpdateProperties` issue already tracked in `fix/unit-update-suppresstriggers-stable9`.

---

## Validation

- `pytest tests/Modules/test_domoticzAbstractLayer.py -q` → 140 passed
- `flake8 Modules/domoticzAbstractLayer.py tests/Modules/test_domoticzAbstractLayer.py --builtins=Devices,Parameters,Connection --count --select=E9,F63,F7,F82` → clean

---

## Unit Test Added

- `test_options_triggers_updateoptions_flag`: asserts `UpdateOptions=True` is forwarded when `Options` is passed.
- `test_no_options_does_not_set_updateoptions_flag`: asserts it stays `False` when `Options` is omitted.
- The fake `Unit.Update()` in the test harness now records its kwargs (`_last_update_kwargs`) so these can be asserted directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArUmyxcgaxn1FSmm2CyPZF