### PR TITLE
Fix ZLinky totalisateur crash on non-numeric index value

### DIFF
--- a/Modules/zlinky.py
+++ b/Modules/zlinky.py
@@ -584,8 +584,21 @@ def zlinky_totalisateur(self, nwkid, attribute, value):
         self.log.logging("ZLinky", "Error", f"zlinky_totalisateur: {nwkid} has no cluster {CLUSTER_ID}")
         return
 
-    # Compute the total
-    total = sum(cluster.get(key, 0) for key in ZLINKY_INDEX_KEYS)
+    # Compute the total. Guard against a non-numeric stored value (e.g. a stale/corrupted
+    # entry left over from a pre-9.1 data format) so a single bad index does not keep the
+    # whole totalisateur - and so the Energy widget - stuck forever.
+    total = 0
+    for key in ZLINKY_INDEX_KEYS:
+        index_value = cluster.get(key, 0)
+        if not isinstance(index_value, (int, float)):
+            self.log.logging(
+                "ZLinky", "Error",
+                f"zlinky_totalisateur: {nwkid} attribute {key} has an unexpected value {index_value!r} "
+                f"({type(index_value).__name__}) instead of a number, resetting it to 0",
+            )
+            cluster[key] = 0
+            index_value = 0
+        total += index_value
 
     # Update and log
     if total < prev_total:


### PR DESCRIPTION
## Summary

Guard `zlinky_totalisateur()` against a non-numeric stored index value instead of crashing, and self-heal the corrupted entry.

---

## Why

A user reported a recurring error after upgrading from stable7 to stable9:

```
TypeError: unsupported operand type(s) for +: 'int' and 'dict'
  File "Modules/zlinky.py", line 588, in zlinky_totalisateur
    total = sum(cluster.get(key, 0) for key in ZLINKY_INDEX_KEYS)
```

`zlinky_totalisateur()` sums the raw `0702` cluster index attributes (`0100`/`0102`/`0104`/`0106`/`0108`/`010a`) assuming they are always numbers. On this user's meter, one of these entries held a non-numeric value (a `dict`), most likely stale/leftover state from a pre-9.1 data format that predates the totalisateur logic (added ~May 2025). Since the function is called on every attribute report and always threw before reaching `checkAndStoreAttributeValue()` for the current attribute, `CompteurTotalisateur` — the value the Meter widget's Energy field is derived from (`zlinky_sum_all_indexes`) — got stuck permanently, while Power kept updating via a separate path. This matches both symptoms reported by the user: repeated errors in the log, and a Meter widget showing Power but no Energy.

---

## Scope

- `Modules/zlinky.py` — `zlinky_totalisateur()`
- Affects ZLinky_TIC devices (all historique/standard variants), cluster `0702`
- Target branch: `stable9`

---

## Details

Replaced the single `sum(cluster.get(key, 0) for key in ZLINKY_INDEX_KEYS)` expression with an explicit loop that validates each stored index value is `int`/`float`. If not, it logs an actionable error (key, value, type) and resets the entry to `0` in the stored cluster data before adding it to the total. This both prevents the crash and permanently repairs the corrupted state (instead of re-crashing on every subsequent report), unblocking the Energy computation.

---

## Validation

- `pytest .` — 1313 passed, 4 skipped
- `flake8 . --builtins=Devices,Parameters,Connection --count --select=E9,F63,F7,F82` — clean on the changed file

---

## Unit Test Added

None. No existing test file covers `Modules/zlinky.py`, and adding one would require introducing test scaffolding beyond the scope of this targeted fix.