### PR TITLE
Fix TypeError when radio backend reports lqi as a float (#1999)

### DIFF
--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -942,7 +942,7 @@ def packet_received(self, packet: zigpy_t.ZigbeePacket) -> None:
         return
 
     # ── 5. General device packet → plugin 0x8002 frame
-    packet.lqi = packet.lqi or 0x00
+    packet.lqi = int(packet.lqi or 0x00)
     effective_profile = 0x0000 if (f["src_ep"] == f["dst_ep"] == 0x00) else f["profile"]
 
     if effective_profile and f["cluster"]:


### PR DESCRIPTION
## Summary

Fix a `TypeError` crash when building the plugin's internal 0x8002 (Data Indication) frame if the radio backend reports `packet.lqi` as a `float`.

## Why

Fixes #1999. Some radio backends can return `lqi` as a float. `packet_received()` in `AppGeneric.py` only did `packet.lqi = packet.lqi or 0x00` — no type coercion — so a later `'%02x' % lqi`-style format raised `TypeError: 'float' object cannot be interpreted as an integer`, breaking Data Indication forwarding for the affected packet.

## Scope

- `Classes/ZigpyTransport/AppGeneric.py` — `packet_received()`, one line.
- Generic across radio backends (ZNP/EZSP/deCONZ/BLZ) since `packet_received` is shared code.

## Details

Coerce with `int(packet.lqi or 0x00)` instead of `packet.lqi or 0x00`, so a float lqi is truncated to an int before it reaches the 0x8002 frame hex formatting.

## Validation

- `flake8 . --select=E9,F63,F7,F82` clean.
- `pytest .` — 1366 passed.

## Unit Test Added

None. This is a one-line defensive type coercion in a hot packet-receive path; the failure mode (backend returning a float lqi) isn't currently reproducible from existing test fixtures without adding a fake backend, and the fix is small/self-evidently correct. Happy to add a regression test if maintainers want one.
