### PR TITLE
Fix Network Topology / Network Energy scan failing on zigpy coordinators

### DIFF
--- a/Classes/NetworkEnergy.py
+++ b/Classes/NetworkEnergy.py
@@ -40,11 +40,12 @@ DURATION = 0x03
 
 
 class NetworkEnergy:
-    def __init__(self, zigbee_communitation, PluginConf, ZigateComm, ListOfDevices, Devices, HardwareID, log, pairing_in_progress):
+    def __init__(self, zigbee_communitation, PluginConf, ZigateComm, ListOfDevices, DeviceConfig, Devices, HardwareID, log, pairing_in_progress):
         self.zigbee_communication = zigbee_communitation
         self.pluginconf = PluginConf
         self.ControllerLink = ZigateComm
         self.ListOfDevices = ListOfDevices
+        self.DeviceConf = DeviceConfig
         self.Devices = Devices
         self.HardwareID = HardwareID
         self.log = log

--- a/Classes/NetworkMap.py
+++ b/Classes/NetworkMap.py
@@ -53,7 +53,7 @@ class NetworkMap:
         self.log = log
         self.FirmwareVersion = None
         self.pairing_in_progress = pairing_in_progress
-        self.DeviceConfig = DeviceConfig
+        self.DeviceConf = DeviceConfig
 
         self._NetworkMapPhase = 0
         self.LQIreqInProgress = []

--- a/Classes/NetworkMap.py
+++ b/Classes/NetworkMap.py
@@ -79,13 +79,23 @@ class NetworkMap:
             self.Neighbours = {}
             
         self.ListOfDevices["0000"]["TopologyStartTime"] = int(time.time())
-        
-        _initNeighbours(self)
-        # Start on Zigate Controler
 
-        prettyPrintNeighbours(self)
-        self._NetworkMapPhase = 2
-        LQIreq(self)
+        try:
+            _initNeighbours(self)
+            # Start on Zigate Controler
+
+            prettyPrintNeighbours(self)
+            self._NetworkMapPhase = 2
+            LQIreq(self)
+
+        except Exception:
+            # Never leave the scan-in-progress marker behind: while TopologyStartTime is set,
+            # remove_entry_from_all_tables() refuses to delete any report and the matching
+            # report is filtered out of get_list_of_timestamps().
+            self.logging("Error", "start_scan - failed to start the Network Topology scan, rolling back")
+            self.ListOfDevices["0000"].pop("TopologyStartTime", None)
+            self._NetworkMapPhase = 0
+            raise
 
     def continue_scan(self):
 
@@ -273,12 +283,13 @@ def finish_scan(self):
     self.logging("Status", "--")
     prettyPrintNeighbours(self)
 
-    storeLQI = { int(self.ListOfDevices["0000"]["TopologyStartTime"]): dict(self.Neighbours) }
+    scan_timestamp = self.ListOfDevices["0000"].get("TopologyStartTime") or int(time.time())
+    storeLQI = { int(scan_timestamp): dict(self.Neighbours) }
 
     if not self.pluginconf.pluginConf["TopologyV2"]:
         save_report_to_file(self, storeLQI)
         
-    del self.ListOfDevices["0000"]["TopologyStartTime"]
+    self.ListOfDevices["0000"].pop("TopologyStartTime", None)
     
 def save_report_to_file(self, storeLQI):
     _filename = Path( self.pluginconf.pluginConf["pluginReports"] ) / ("NetworkTopology-v3-" + "%02d.json" % self.HardwareID)

--- a/Classes/WebServer/dispatcher.py
+++ b/Classes/WebServer/dispatcher.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier:    GPL-3.0 license
 
 import json
+import traceback
 
 from Classes.WebServer.headerResponse import (prepResponseMessage,
                                               setupHeadersResponse)
@@ -113,7 +114,14 @@ def do_rest(self, Connection, verb, data, version, command, parameters):
 
     if command in self.REST_COMMANDS and verb in self.REST_COMMANDS[command]["Verbs"]:
         self.logging("Debug", f"do_rest - Verb: {verb}, Command: {command}, Param: {parameters} found, ready to execute")
-        HTTPresponse = execute_rest_command(self, verb, data, version, command, parameters)
+        try:
+            HTTPresponse = execute_rest_command(self, verb, data, version, command, parameters)
+        except Exception as e:
+            # Do not let an exception bubble up to handle_client(), which would close the socket
+            # without any HTTP response and leave the WebUI with a 'Error 0 Unknown Error'
+            self.logging("Error", f"do_rest - Verb: {verb}, Command: {command}, Param: {parameters} raised {type(e).__name__}: {e}")
+            self.logging("Error", f"{traceback.format_exc()}")
+            HTTPresponse = prepare_internal_error_message(self, command, e)
     else:
         self.logging("Error", f"do_rest - Verb: {verb}, Command: {command}, Param: {parameters} not found!")
 
@@ -155,6 +163,16 @@ def prepare_help_response(self):
     response["Data"] = json.dumps({
         x: {"Verbs": sorted(self.REST_COMMANDS[x]["Verbs"])} for x in self.REST_COMMANDS
     })
+    return response
+
+
+def prepare_internal_error_message(self, command, exception):
+    response = prepResponseMessage(self, setupHeadersResponse())
+    response.update({
+        "Status": "500 INTERNAL SERVER ERROR",
+        "Data": f"REST command {command} failed: {type(exception).__name__}: {exception}",
+    })
+    response["Headers"]["Content-Type"] = "text/plain; charset=utf-8"
     return response
 
 

--- a/Classes/ZigpyTopology.py
+++ b/Classes/ZigpyTopology.py
@@ -27,7 +27,7 @@ class ZigpyTopology:
         self.ControllerLink = ZigateComm
         self.ListOfDevices = ListOfDevices
         self.IEEE2NWK = IEEE2NWK
-        self.DeviceConfig = DeviceConfig
+        self.DeviceConf = DeviceConfig
         self.Devices = Devices
         self.HardwareID = HardwareID
         self.log = log

--- a/plugin.py
+++ b/plugin.py
@@ -1471,7 +1471,7 @@ def zigateInit_Phase3(self):
     # Create Network Energy object
     if self.networkenergy is None:
         self.networkenergy = NetworkEnergy(
-            self.zigbee_communication, self.pluginconf, self.ControllerLink, self.ListOfDevices, Devices, self.HardwareID, self.log, self.pairing_in_progress
+            self.zigbee_communication, self.pluginconf, self.ControllerLink, self.ListOfDevices, self.DeviceConf, Devices, self.HardwareID, self.log, self.pairing_in_progress
         )
 
     if self.networkenergy:

--- a/tests/Classes/test_scan_classes_deviceconf.py
+++ b/tests/Classes/test_scan_classes_deviceconf.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Regression coverage for the "Interface Error 0 / Unknown Error" reported by the
+WebUI when starting a Network Topology (or Network Energy) scan on a zigpy
+coordinator.
+
+zigpy coordinators always run with ControllerInRawMode = True (plugin.py), so
+every ZDP request issued by NetworkMap / NetworkEnergy goes through
+raw_APS_request() -> zigpy_raw_APS_request() -> device_listening_on_iddle(),
+which resolves the certified-device configuration through `self.DeviceConf`.
+
+NetworkMap and ZigpyTopology used to store that dict as `self.DeviceConfig`,
+and NetworkEnergy did not carry it at all, so the very first ZDP request of a
+scan raised `AttributeError: ... object has no attribute 'DeviceConf'`. The
+exception escaped do_rest() up to handle_client(), which closed the socket
+without ever sending an HTTP response -- the WebUI then reported HTTP status 0.
+
+These tests pin the attribute name that
+Modules.tools_model.get_deviceconf_parameter_value expects, on every object
+that is passed as `self` down the raw APS path.
+
+The scan classes import the real Modules.* package, which conflicts with the
+stubs tests/conftest.py installs for the rest of the session. The checks are
+therefore executed in a subprocess, fully isolated from the pytest session.
+"""
+
+import subprocess  # nosec B404
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PREAMBLE = textwrap.dedent(
+    """
+    import sys, types
+    from unittest.mock import MagicMock
+
+    domoticz = types.ModuleType("DomoticzEx")
+    for _name in ("Unit", "Connection", "Log", "Debug", "Error", "Status"):
+        setattr(domoticz, _name, MagicMock(name=_name))
+    domoticz.Configuration = MagicMock(name="Configuration", return_value={})
+    sys.modules["DomoticzEx"] = domoticz
+
+    DEVICE_CONF = {"TRADFRI Signal Repeater": {"ReceiveOnIdle": False}}
+
+    class Log:
+        def logging(self, *args, **kwargs):
+            pass
+
+    def make_network_map():
+        from Classes.NetworkMap import NetworkMap
+        return NetworkMap(
+            "zigpy", {"TopologyV2": 1}, MagicMock(), {"0000": {}}, DEVICE_CONF, {}, 1, Log(), False
+        )
+
+    def make_network_energy():
+        from Classes.NetworkEnergy import NetworkEnergy
+        return NetworkEnergy(
+            "zigpy", {}, MagicMock(), {"0000": {}}, DEVICE_CONF, {}, 1, Log(), False
+        )
+    """
+)
+
+
+def _run(snippet):
+    """Execute `snippet` against the real (unstubbed) plugin modules."""
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", PREAMBLE + textwrap.dedent(snippet)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    return result.stdout.strip()
+
+
+@pytest.mark.parametrize("factory", ["make_network_map", "make_network_energy"])
+def test_scan_class_exposes_deviceconf(factory):
+    """The raw APS path reads self.DeviceConf -- not self.DeviceConfig."""
+    assert _run(f"""
+        instance = {factory}()
+        assert instance.DeviceConf is DEVICE_CONF, "DeviceConf not exposed"
+        print("ok")
+    """) == "ok"
+
+
+@pytest.mark.parametrize("factory", ["make_network_map", "make_network_energy"])
+def test_device_listening_on_iddle_accepts_scan_class(factory):
+    """device_listening_on_iddle() is called with the scan object as `self`."""
+    assert _run(f"""
+        from Modules.tools_mac_capa import device_listening_on_iddle
+        instance = {factory}()
+        instance.ListOfDevices["0000"] = {{"Model": "TRADFRI Signal Repeater", "Capability": []}}
+        # Must not raise AttributeError on self.DeviceConf
+        assert device_listening_on_iddle(instance, "0000") is False
+        print("ok")
+    """) == "ok"
+
+
+def test_zigpy_topology_exposes_deviceconf():
+    pytest.importorskip("zigpy")
+    assert _run("""
+        from Classes.ZigpyTopology import ZigpyTopology
+        instance = ZigpyTopology(
+            "zigpy", {}, MagicMock(), {"0000": {}}, {}, DEVICE_CONF, {}, 1, Log(), False
+        )
+        assert instance.DeviceConf is DEVICE_CONF, "DeviceConf not exposed"
+        print("ok")
+    """) == "ok"

--- a/tests/Classes/test_scan_classes_deviceconf.py
+++ b/tests/Classes/test_scan_classes_deviceconf.py
@@ -102,6 +102,53 @@ def test_device_listening_on_iddle_accepts_scan_class(factory):
     """) == "ok"
 
 
+def test_start_scan_rolls_back_topology_start_time_on_failure():
+    """A failing start_scan() must not leave the scan-in-progress marker behind.
+
+    While ListOfDevices["0000"]["TopologyStartTime"] is set,
+    remove_entry_from_all_tables() refuses to delete any report and the matching
+    report is filtered out of get_list_of_timestamps() -- so a scan that dies on
+    its first ZDP request would otherwise make the WebUI report list unusable
+    until the next successful scan.
+    """
+    assert _run("""
+        import Classes.NetworkMap as nm
+
+        instance = make_network_map()
+
+        def boom(_self):
+            raise RuntimeError("ZDP request failed")
+
+        nm._initNeighbours = boom
+
+        try:
+            instance.start_scan()
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("start_scan() swallowed the failure")
+
+        assert "TopologyStartTime" not in instance.ListOfDevices["0000"], "marker leaked"
+        assert instance.NetworkMapPhase() == 0, "scan phase left in progress"
+        print("ok")
+    """) == "ok"
+
+
+def test_finish_scan_tolerates_missing_topology_start_time():
+    """finish_scan() must not raise KeyError if the marker is already gone."""
+    assert _run("""
+        import Classes.NetworkMap as nm
+
+        instance = make_network_map()
+        instance.pluginconf = type("Conf", (), {"pluginConf": {"TopologyV2": 1}})()
+        instance.Neighbours = {}
+
+        # No TopologyStartTime set at all
+        nm.finish_scan(instance)
+        print("ok")
+    """) == "ok"
+
+
 def test_zigpy_topology_exposes_deviceconf():
     pytest.importorskip("zigpy")
     assert _run("""


### PR DESCRIPTION

## Why

Reported by a user who could not start a Network Topology report from the WebUI. Analysis of `PluginZigbee_02.log` showed the request never produced any plugin-side activity — not even the `Request a Start of Network Topology scan` line, which is emitted at *Status* level and is therefore never filtered.

The root cause is an attribute-name mismatch on the raw APS path:

- zigpy coordinators always run with `ControllerInRawMode = True` (forced in `plugin.py:1240`).
- In raw mode every ZDP request goes through `raw_APS_request()` → `zigpy_raw_APS_request()`, which calls `device_listening_on_iddle()` to compute `RxOnIdle`.
- `device_listening_on_iddle()` resolves the certified-device configuration via `get_deviceconf_parameter_value()`, which reads **`self.DeviceConf`**.
- `NetworkMap` stored that dict as `self.DeviceConfig`, and `NetworkEnergy` did not carry it at all.

So the very first ZDP request of a scan raised:

```
AttributeError: 'NetworkMap' object has no attribute 'DeviceConf'
```

Nothing between the REST handler and the socket catches it: `rest_req_topologie` → `execute_rest_command` → `do_rest` → `onMessage` all lack a `try`. The exception lands in `com.py:200`, which logs the traceback and then `break`s — closing the socket **without ever sending an HTTP response**. The browser gets a dropped connection with no status line, so Angular reports `status: 0, statusText: "Unknown Error"`.

Regression introduced by `4be23641` (2025-05-21), which added the `ReceiveOnIdle` / `self.DeviceConf` lookup inside `device_listening_on_iddle()`.

---

## Scope

- **Branch:** `stable9`
- **Files:** `Classes/NetworkMap.py`, `Classes/ZigpyTopology.py`, `Classes/NetworkEnergy.py`, `Classes/WebServer/dispatcher.py`, `plugin.py`
- **Commits:** `8dc17d3d` (the `DeviceConf` fix + REST guard), `7dece440` (scan-state rollback)
- **Radios:** all zigpy backends (ZNP, EZSP/Bellows, deCONZ, BLZ) — raw mode is forced for all of them. Native ZiGate is unaffected (`ControllerInRawMode = False`).
- **Affected users:** zigpy setups with `ZigpyTopologyReport = 0`, which routes topology through the legacy `NetworkMap` path. `TopologyV2` is irrelevant — with `TopologyV2 = 0` the crash simply moves from `mgmt_rtg → mgt_routing_req` to `LQIreq → zdp_nwk_lqi_request`, both of which reach `raw_APS_request`.
- With the default `ZigpyTopologyReport = 1`, `ZigpyTopology` is used and dispatches via `ControllerLink.sendData("ZIGPY-TOPOLOGY-SCAN")`, never touching `raw_APS_request` — which is why this was not widely reported.
- **The Network Energy scan is affected by the same defect** (`NwkScanReq` → `zdp_management_network_update_request` → raw → `device_listening_on_iddle`).
- No persistent data format change, no device-behaviour change, no public signature change outside `NetworkEnergy.__init__` (single call site, in `plugin.py`).

---

## Details

1. `Classes/NetworkMap.py` — `self.DeviceConfig = DeviceConfig` → `self.DeviceConf = DeviceConfig`. The attribute was assigned and never read anywhere else, so the rename is self-contained.
2. `Classes/ZigpyTopology.py` — same rename, for consistency with every other class (`OTA`, `IAS`, `ConfigureReporting` all use `DeviceConf`).
3. `Classes/NetworkEnergy.py` — `__init__` gains a `DeviceConfig` parameter, stored as `self.DeviceConf`.
4. `plugin.py` — the single `NetworkEnergy(...)` call site now passes `self.DeviceConf`.
5. `Classes/WebServer/dispatcher.py` — `execute_rest_command()` is wrapped in `try/except` inside `do_rest()`. A handler exception is now logged with its traceback and answered with a `500 INTERNAL SERVER ERROR` carrying the exception type and message, instead of escaping to `handle_client()` and dropping the connection. This is the part that makes any future handler failure diagnosable from the WebUI rather than showing `Error 0`.
6. `Classes/NetworkMap.py` — `start_scan()` sets `ListOfDevices["0000"]["TopologyStartTime"]` before issuing the first ZDP request, and only `finish_scan()` removes it, so any failure in between left the scan-in-progress marker behind. While that marker is set, `remove_entry_from_all_tables()` refuses to delete any report (`zb_tables_management.py:195`) and the matching report is filtered out of `get_list_of_timestamps()` (line 179) — the WebUI report list becomes unusable until the next successful scan. `start_scan()` now rolls the marker back and resets `_NetworkMapPhase` before re-raising, so the failure still surfaces to the caller.
7. `Classes/NetworkMap.py` — `finish_scan()` no longer assumes `TopologyStartTime` is present. It was read unguarded when building `storeLQI`, a latent `KeyError` on the path that writes the report.

### No startup cleanup needed

An earlier draft of this PR proposed clearing a stale `TopologyStartTime` at load time. That is unnecessary: the key is in neither `CIE_ATTRIBUTES` (TXT path, `CheckDeviceList` rebuilds `ListOfDevices["0000"]` from scratch) nor `MANDATORY ∪ MANUFACTURER ∪ BUILD_ATTRIBUTES` (Domoticz Db path, `retreive_device_list_from_domoticz` pops everything outside that set). Both loaders already drop it, so the marker cannot survive a restart and no migration or manual cleanup is required for affected installs.

A staleness timeout was considered and rejected for the same reason — with the loaders sanitising and `start_scan()` now rolling back, its only effect would be a new failure mode: declaring a genuinely slow scan on a large mesh dead mid-flight.

---

## Validation

- Reproduced the `AttributeError` directly against `device_listening_on_iddle()` with a `NetworkMap`-shaped object before the fix.
- Traced the full call chain from the REST entry point: `rest_Topology.py:43` → `NetworkMap.start_scan()` → `_initNeighbours` → `_initNeighboursTableEntry("0000")` → `mgmt_rtg` → `mgt_routing_req` → `zdp_management_routing_table_request` → `raw_APS_request` → `zigpy_raw_APS_request` → `device_listening_on_iddle` → `self.DeviceConf`.
- New regression tests: **6 failures against unpatched `stable9`, all pass after**.
- Full suite: `1362 passed, 4 skipped` on `stable9` → `1368 passed, 5 skipped` with this branch. No regressions. (The extra skip is the `ZigpyTopology` case, gated on `zigpy` being importable; it runs in CI.)
- `flake8 . --builtins=Devices,Parameters,Connection --select=E9,F63,F7,F82` → 0.
- `bandit` on the changed files → only `B101 assert_used` in the new test file, consistent with the rest of `tests/`.

Field validation still wanted: start a Network Topology scan from the WebUI with `ZigpyTopologyReport = 0` on a real coordinator, and confirm a Network Energy scan still completes.

---

## Unit Test Added

`tests/Classes/test_scan_classes_deviceconf.py` — pins the attribute name that `get_deviceconf_parameter_value()` expects on every object passed as `self` down the raw APS path:

- `test_scan_class_exposes_deviceconf` — `NetworkMap` and `NetworkEnergy` expose `DeviceConf`.
- `test_device_listening_on_iddle_accepts_scan_class` — calling `device_listening_on_iddle()` with a scan object does not raise.
- `test_zigpy_topology_exposes_deviceconf` — same check for `ZigpyTopology` (skipped when `zigpy` is not installed).

And for the scan-state rollback:

- `test_start_scan_rolls_back_topology_start_time_on_failure` — a failing `start_scan()` re-raises, leaves no `TopologyStartTime` behind, and resets the scan phase.
- `test_finish_scan_tolerates_missing_topology_start_time` — `finish_scan()` does not raise `KeyError` when the marker is already gone.

The scan classes import the real `Modules.*` package, which conflicts with the stubs `tests/conftest.py` installs session-wide. An earlier draft that imported them at module level silently broke three unrelated tests through `sys.modules` pollution, so the checks run in a subprocess and are fully isolated from the pytest session.