### PR TITLE
Fix Python module requirements check using packaging specifiers

### DIFF
--- a/Modules/pluginHelpers.py
+++ b/Modules/pluginHelpers.py
@@ -10,6 +10,9 @@
 #
 # SPDX-License-Identifier:    GPL-3.0 license
 
+"""Misc plugin lifecycle helpers: Domoticz/firmware version checks, device-database
+housekeeping, and Python module requirements validation against constraints.txt."""
+
 import importlib.metadata
 import re
 import sys
@@ -22,6 +25,7 @@ from packaging.version import Version
 from Modules.domoticzAbstractLayer import domoticz_error_api
 from Modules.tools import how_many_devices
 
+# zigpy-family modules tracked by parse_constraints()/check_python_modules_version()
 PYTHON_MODULES = {
     "zigpy",
     "zigpy_znp",
@@ -30,6 +34,7 @@ PYTHON_MODULES = {
 }
 
 def networksize_update(self):
+    """Refresh the NetworkSize plugin parameter from the current device count."""
     self.log.logging("Plugin", "Debug", "Devices size has changed , let's write ListOfDevices on disk")
     routers, enddevices = how_many_devices(self)
     self.pluginParameters["NetworkSize"] = "Total: %s | Routers: %s | End Devices: %s" %(
@@ -37,7 +42,7 @@ def networksize_update(self):
 
 
 def decodeConnection(connection):
-
+    """Parse a Domoticz Connection.Description-style string into a dict."""
     decoded = {}
     for i in connection.strip().split(","):
         label, value = i.split(": ")
@@ -48,6 +53,7 @@ def decodeConnection(connection):
 
 
 def check_firmware_level(self):
+    """Validate the ZiGate firmware version and flag Pluzzy-specific firmware."""
     # Check Firmware version
     if int(self.FirmwareVersion.lower(),16) == 0x2100:
         self.log.logging("Plugin", "Status", "Firmware for Pluzzy devices")
@@ -66,15 +72,14 @@ def check_firmware_level(self):
 
 
 def update_DB_device_status_to_reinit( self ):
-
-    # This function is called because the ZiGate will be reset, and so it is expected that all devices will be reseted and repaired
-
+    """Mark every 'inDB' device as 'erasePDM' ahead of a ZiGate reset/re-pair."""
     for x in self.ListOfDevices:
         if 'Status' in self.ListOfDevices[ x ] and self.ListOfDevices[ x ]['Status'] == 'inDB':
             self.ListOfDevices[ x ]['Status'] = 'erasePDM'
 
 
 def get_domoticz_version( self, domoticz_version  ):
+    """Parse Domoticz's version string and populate self.DomoticzMajor/Minor/Build."""
     lst_version = domoticz_version.split(" ")
     if len(lst_version) == 1:
         return _old_fashon_domoticz(self, lst_version, domoticz_version)
@@ -92,7 +97,7 @@ def get_domoticz_version( self, domoticz_version  ):
 
 
 def _old_fashon_domoticz(self, lst_version, domoticz_version):
-    # No Build
+    """Handle the legacy Domoticz version format that carries no build number."""
     major, minor = lst_version[0].split(".")
     self.DomoticzBuild = 0
     _update_domoticz_firmware_data(self, major, minor)
@@ -107,18 +112,24 @@ def _old_fashon_domoticz(self, lst_version, domoticz_version):
 
 
 def _update_domoticz_firmware_data(self, major, minor):
+    """Store the parsed Domoticz major/minor version and mark it as new-fashion."""
     self.DomoticzMajor = int(major)
     self.DomoticzMinor = int(minor)
     self.VersionNewFashion = True
 
 
 def _domoticz_not_compatible(self):
+    """Stop the plugin because the running Domoticz version is unsupported."""
     self.VersionNewFashion = False
     self.onStop()
     return False
 
 
 def check_python_modules_version(self):
+    """Log an error for each loaded zigpy-family module that violates constraints.txt.
+
+    No-op (returns True) when the "internetAccess" plugin setting is enabled.
+    """
     if self.pluginconf.pluginConf["internetAccess"]:
         return True
 
@@ -134,6 +145,7 @@ def check_python_modules_version(self):
 
 
 def list_all_modules_loaded(self):
+    """Log every imported/installed Python module and its version, for debugging."""
     # Get a list of modules imported by the main script
     main_modules = set(sys.modules.keys())
 
@@ -153,6 +165,7 @@ def list_all_modules_loaded(self):
 
 
 def parse_constraints(home_folder):
+    """Read constraints.txt and return {module: SpecifierSet} for the zigpy-family modules in PYTHON_MODULES."""
     constraints_file = Path(home_folder) / "constraints.txt"
     constraints = {}
 
@@ -174,7 +187,11 @@ def parse_constraints(home_folder):
 
 
 def check_requirements(home_folder):
+    """Validate every constraints.txt entry against the installed package versions.
 
+    Returns True if all constraints are satisfied, False otherwise (logging the
+    specific package/constraint that failed via Domoticz.Error).
+    """
     constraints_file = Path(home_folder) / "constraints.txt"
 
     Domoticz.Status(

--- a/Modules/pluginHelpers.py
+++ b/Modules/pluginHelpers.py
@@ -133,7 +133,7 @@ def check_python_modules_version(self):
     if self.pluginconf.pluginConf["internetAccess"]:
         return True
 
-    constraints = parse_constraints(self.pluginParameters["HomeFolder"])
+    constraints = parse_constraints(self.pluginParameters["HomeFolder"], PYTHON_MODULES)
     for module, specifier in constraints.items():
         current_version = Version(importlib.metadata.version(module))
         if current_version not in specifier:
@@ -164,8 +164,13 @@ def list_all_modules_loaded(self):
     self.log.logging("Plugin", "Log", "=============================")
 
 
-def parse_constraints(home_folder):
-    """Read constraints.txt and return {module: SpecifierSet} for the zigpy-family modules in PYTHON_MODULES."""
+def parse_constraints(home_folder, packages=None):
+    """Read constraints.txt and return {package: SpecifierSet}.
+
+    Only entries whose package name is in `packages` are kept when it is
+    given; otherwise every entry in the file is returned. Raises
+    packaging.specifiers.InvalidSpecifier if a constraint cannot be parsed.
+    """
     constraints_file = Path(home_folder) / "constraints.txt"
     constraints = {}
 
@@ -178,12 +183,13 @@ def parse_constraints(home_folder):
 
             package = re.split(r"[<>!=~]+", line, maxsplit=1)[0].strip()
 
-            if package in PYTHON_MODULES:
-                constraint = line[len(package):].strip()
-                constraints[package] = SpecifierSet(constraint)
+            if not package or (packages is not None and package not in packages):
+                continue
+
+            constraint = line[len(package):].strip()
+            constraints[package] = SpecifierSet(constraint)
 
     return constraints
-
 
 
 def check_requirements(home_folder):
@@ -198,59 +204,43 @@ def check_requirements(home_folder):
         f"Z4D checks Python modules {constraints_file}"
     )
 
-    with constraints_file.open("r") as file:
+    try:
+        constraints = parse_constraints(home_folder)
+    except ValueError as error:
+        Domoticz.Error(f"Invalid version constraint in {constraints_file}: {error}")
+        return False
 
-        for line in file:
+    for package, specifier in constraints.items():
 
-            req_str = line.split("#", 1)[0].strip()
+        try:
+            installed_version = Version(importlib.metadata.version(package))
 
-            if not req_str:
-                continue
-
-            package = re.split(
-                r"[<>!=~]+",
-                req_str,
-                maxsplit=1,
-            )[0].strip()
-
-            if not package:
-                continue
-
-            constraint = req_str[len(package):].strip()
-
-            try:
-                installed_version = Version(
-                    importlib.metadata.version(package)
-                )
-
-                specifier = SpecifierSet(constraint)
-
-            except importlib.metadata.PackageNotFoundError:
-                Domoticz.Error(
-                    f"Python module {package} is not installed. "
-                    f"Required constraint: {req_str}"
-                )
-                return False
-
-            except ValueError as error:
-                Domoticz.Error(
-                    f"Invalid version constraint '{req_str}': {error}"
-                )
-                return False
-
-            if installed_version not in specifier:
-
-                Domoticz.Error(
-                    f"Python module {package} version "
-                    f"{installed_version} does not satisfy "
-                    f"constraint {constraint}"
-                )
-
-                return False
-
-            Domoticz.Status(
-                f"   - {package} {installed_version} "
-                f"satisfies {constraint}"
+        except importlib.metadata.PackageNotFoundError:
+            Domoticz.Error(
+                f"Python module {package} is not installed. "
+                f"Required constraint: {specifier}"
             )
+            return False
+
+        except ValueError as error:
+            Domoticz.Error(
+                f"Invalid installed version for {package}: {error}"
+            )
+            return False
+
+        if installed_version not in specifier:
+
+            Domoticz.Error(
+                f"Python module {package} version "
+                f"{installed_version} does not satisfy "
+                f"constraint {specifier}"
+            )
+
+            return False
+
+        Domoticz.Status(
+            f"   - {package} {installed_version} "
+            f"satisfies {specifier}"
+        )
 
     return True

--- a/Modules/pluginHelpers.py
+++ b/Modules/pluginHelpers.py
@@ -16,10 +16,18 @@ import sys
 from pathlib import Path
 
 import DomoticzEx as Domoticz
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
-from Modules.tools import how_many_devices
 from Modules.domoticzAbstractLayer import domoticz_error_api
+from Modules.tools import how_many_devices
 
+PYTHON_MODULES = {
+    "zigpy",
+    "zigpy_znp",
+    "zigpy_deconz",
+    "bellows",
+}
 
 def networksize_update(self):
     self.log.logging("Plugin", "Debug", "Devices size has changed , let's write ListOfDevices on disk")
@@ -114,72 +122,15 @@ def check_python_modules_version(self):
     if self.pluginconf.pluginConf["internetAccess"]:
         return True
 
-    zigpy_modules_version = parse_constraints(self.pluginParameters["HomeFolder"])
-    for module, expected_version in zigpy_modules_version.items():
-        current_version = importlib.metadata.version(module)
-        if current_version != expected_version:
-            self.log.logging("Plugin", "Error", "The Python module %s version %s loaded is not compatible. Expected version: %s" % (
-                module, current_version, expected_version))
+    constraints = parse_constraints(self.pluginParameters["HomeFolder"])
+    for module, specifier in constraints.items():
+        current_version = Version(importlib.metadata.version(module))
+        if current_version not in specifier:
+            self.log.logging("Plugin", "Error", "The Python module %s version %s loaded is not compatible. Expected: %s" % (
+                module, current_version, specifier))
             return False
 
     return True
-
-
-def check_requirements(home_folder):
-
-    requirements_file = Path(home_folder) / "constraints.txt"
-    Domoticz.Status("Z4D checks Python modules %s" % requirements_file)
-
-    with open(requirements_file, 'r') as file:
-        requirements_list = file.readlines()
-
-    for req_str in requirements_list:
-        req_str = req_str.strip()
-
-        package = re.split(r'[<>!=]+', req_str)[0].strip()
-        if package == "":
-            continue
-        version = None
-        try:
-            installed_version = importlib.metadata.version(package)
-
-            version = None
-            if '==' in req_str:
-                version = re.split('==', req_str)[1].strip()
-                if installed_version != version:
-                    python_module_with_wrong_version( req_str, version, installed_version)
-                    return True
-            elif '>=' in req_str:
-                version = re.split('>=', req_str)[1].strip()
-                if installed_version < version:
-                    python_module_with_wrong_version( req_str, version, installed_version)
-                    return True
-            elif '<=' in req_str:
-                version = re.split('<=', req_str)[1].strip()
-                if installed_version > version:
-                    python_module_with_wrong_version( req_str, version, installed_version)
-                    return True
-
-        except importlib.metadata.PackageNotFoundError as e:
-            Domoticz.Error(f"An unexpected error occurred while checking package {package} - {req_str} - {e}")
-            return True
-
-        except importlib.metadata.MetadataError as e:
-            Domoticz.Error(f"An unexpected error occurred while checking {package} - {req_str} - {e}")
-            return True
-
-        except Exception as e:
-            Domoticz.Error(f"An unexpected error occurred: {package} - {e}")
-            return True
-
-        Domoticz.Status(f"   - {req_str} version required {version} installed {installed_version}")
-    return False
-
-def python_module_with_wrong_version( req_str, version, installed_version):
-    Domoticz.Error(f"Looks like {req_str} Python module is not installed or does not meet the required version. Requires {version}, Installed {installed_version}." 
-                   f"Make sure to install the required Python3 module with the correct version.")
-    Domoticz.Error("Use the command:")
-    Domoticz.Error("sudo python3 -m pip install -r requirements.txt --upgrade")
 
 
 def list_all_modules_loaded(self):
@@ -202,34 +153,87 @@ def list_all_modules_loaded(self):
 
 
 def parse_constraints(home_folder):
-    modules_version = {
-        "zigpy": "",
-        "zigpy_znp": "",
-        "zigpy_deconz": "",
-        "bellows": ""
-    }
-
     constraints_file = Path(home_folder) / "constraints.txt"
-    with open(constraints_file, 'r') as file:
-        for line in file:
-            # Remove leading/trailing whitespace and newlines
-            line = line.strip()
+    constraints = {}
 
-            # Split line into module name and version
-            if '==' in line:
-                module, version = line.split('==')
-            elif '>=' in line:
-                module, version = line.split('>=')
-            elif '<=' in line:
-                module, version = line.split('<=')
-            else:
+    with constraints_file.open("r") as file:
+        for line in file:
+            line = line.split("#", 1)[0].strip()
+
+            if not line:
                 continue
 
-            # Check if the module is one we are interested in
-            if module in modules_version:
-                modules_version[module] = version
+            package = re.split(r"[<>!=~]+", line, maxsplit=1)[0].strip()
 
-    # Remove any entries where version is still empty
-    modules_version = {k: v for k, v in modules_version.items() if v}
+            if package in PYTHON_MODULES:
+                constraint = line[len(package):].strip()
+                constraints[package] = SpecifierSet(constraint)
 
-    return modules_version
+    return constraints
+
+
+
+def check_requirements(home_folder):
+
+    constraints_file = Path(home_folder) / "constraints.txt"
+
+    Domoticz.Status(
+        f"Z4D checks Python modules {constraints_file}"
+    )
+
+    with constraints_file.open("r") as file:
+
+        for line in file:
+
+            req_str = line.split("#", 1)[0].strip()
+
+            if not req_str:
+                continue
+
+            package = re.split(
+                r"[<>!=~]+",
+                req_str,
+                maxsplit=1,
+            )[0].strip()
+
+            if not package:
+                continue
+
+            constraint = req_str[len(package):].strip()
+
+            try:
+                installed_version = Version(
+                    importlib.metadata.version(package)
+                )
+
+                specifier = SpecifierSet(constraint)
+
+            except importlib.metadata.PackageNotFoundError:
+                Domoticz.Error(
+                    f"Python module {package} is not installed. "
+                    f"Required constraint: {req_str}"
+                )
+                return False
+
+            except ValueError as error:
+                Domoticz.Error(
+                    f"Invalid version constraint '{req_str}': {error}"
+                )
+                return False
+
+            if installed_version not in specifier:
+
+                Domoticz.Error(
+                    f"Python module {package} version "
+                    f"{installed_version} does not satisfy "
+                    f"constraint {constraint}"
+                )
+
+                return False
+
+            Domoticz.Status(
+                f"   - {package} {installed_version} "
+                f"satisfies {constraint}"
+            )
+
+    return True

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,3 +8,4 @@ serialx>=1.4.0
 charset-normalizer==2.0.11
 jsonschema==4.17.3
 cryptography<=40.0.2
+packaging>=21.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,4 +8,3 @@ serialx>=1.4.0
 charset-normalizer==2.0.11
 jsonschema==4.17.3
 cryptography<=40.0.2
-packaging>=21.3

--- a/plugin.py
+++ b/plugin.py
@@ -475,8 +475,8 @@ class BasePlugin:
 
         if self.internet_available and self.pluginconf.pluginConf.get("CheckRequirements", True):
             Domoticz.Status("Z4D checks the Python modules requirements")
-            if check_requirements( Parameters[ "HomeFolder"] ):
-                # Check_requirements() return True if requirements not meet.
+            if not check_requirements( Parameters[ "HomeFolder"] ):
+                # check_requirements() returns False if requirements are not met.
                 self.onStop()
                 return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -c constraints.txt
+packaging
 zigpy
 zigpy-cli
 dnspython
@@ -10,8 +11,8 @@ zigpy-blz
 zigpy_deconz
 bellows
 requests
-distro
 pyserial
+serialx
 charset-normalizer
 jsonschema
 cryptography

--- a/tests/Modules/test_pluginHelpers.py
+++ b/tests/Modules/test_pluginHelpers.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for Modules.pluginHelpers.py, focused on the constraints-parsing
+and Python-module version-checking helpers (parse_constraints,
+check_requirements, check_python_modules_version, list_all_modules_loaded).
+
+Modules.pluginHelpers imports the real Modules.tools / Modules.domoticzAbstractLayer
+package chain, which conflicts with the session-wide stubs installed by
+tests/conftest.py for the rest of the suite. As documented for the sibling
+tests in tests/Classes/test_scan_classes_deviceconf.py, these checks are
+therefore executed in a subprocess, fully isolated from the pytest session,
+with only DomoticzEx faked (the only piece of the chain that is genuinely
+unavailable outside a real Domoticz install).
+"""
+
+import subprocess  # nosec B404
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PREAMBLE = textwrap.dedent(
+    """
+    import sys, types, tempfile
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    ERRORS = []
+    STATUSES = []
+
+    domoticz = types.ModuleType("DomoticzEx")
+    domoticz.Error = lambda msg: ERRORS.append(msg)
+    domoticz.Status = lambda msg: STATUSES.append(msg)
+    domoticz.Log = MagicMock(name="Log")
+    domoticz.Debug = MagicMock(name="Debug")
+    domoticz.Unit = MagicMock(name="Unit")
+    domoticz.Connection = MagicMock(name="Connection")
+    sys.modules["DomoticzEx"] = domoticz
+
+    import importlib.metadata as im
+    import Modules.pluginHelpers as ph
+
+    def make_home(constraints_text):
+        home = tempfile.mkdtemp()
+        (Path(home) / "constraints.txt").write_text(constraints_text)
+        return home
+
+    def fake_versions(mapping):
+        im.version = lambda name: mapping[name]
+
+    def fake_missing_package():
+        def _raise(name):
+            raise im.PackageNotFoundError(name)
+        im.version = _raise
+
+    def make_self(home_folder, internet_access=False):
+        return types.SimpleNamespace(
+            pluginconf=types.SimpleNamespace(pluginConf={"internetAccess": internet_access}),
+            pluginParameters={"HomeFolder": home_folder},
+            log=types.SimpleNamespace(logging=lambda *a, **k: LOGS.append(a)),
+        )
+
+    LOGS = []
+    """
+)
+
+
+def _run(snippet):
+    """Execute `snippet` against the real (unstubbed) pluginHelpers module."""
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", PREAMBLE + textwrap.dedent(snippet)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the ImportError that broke plugin.py
+# ---------------------------------------------------------------------------
+
+def test_all_symbols_imported_by_plugin_are_exported():
+    """
+    plugin.py does:
+        from Modules.pluginHelpers import (check_firmware_level,
+            check_python_modules_version, check_requirements, decodeConnection,
+            get_domoticz_version, list_all_modules_loaded, networksize_update,
+            update_DB_device_status_to_reinit)
+
+    A prior revision removed check_python_modules_version and
+    list_all_modules_loaded while leaving these imports in plugin.py, which
+    made the whole plugin fail to import at startup. Guard against a repeat.
+    """
+    assert _run(
+        """
+        names = [
+            "check_firmware_level", "check_python_modules_version",
+            "check_requirements", "decodeConnection", "get_domoticz_version",
+            "list_all_modules_loaded", "networksize_update",
+            "update_DB_device_status_to_reinit",
+        ]
+        for name in names:
+            assert callable(getattr(ph, name)), name
+        print("ok")
+        """
+    ) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# parse_constraints
+# ---------------------------------------------------------------------------
+
+def test_parse_constraints_keeps_only_tracked_modules():
+    assert _run(
+        """
+        home = make_home("\\n".join([
+            "zigpy==2.1.0",
+            "zigpy_znp>=1.0.0,<2.0.0",
+            "unrelated-package==9.9.9",
+            "# a comment line",
+            "bellows~=1.0",
+            "",
+        ]))
+        constraints = ph.parse_constraints(home)
+        assert set(constraints) == {"zigpy", "zigpy_znp", "bellows"}, constraints
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_parse_constraints_builds_usable_specifiers():
+    assert _run(
+        """
+        from packaging.version import Version
+        home = make_home("\\n".join([
+            "zigpy==2.1.0",
+            "zigpy_znp>=1.0.0,<2.0.0",
+        ]))
+        constraints = ph.parse_constraints(home)
+        assert Version("2.1.0") in constraints["zigpy"]
+        assert Version("2.0.0") not in constraints["zigpy"]
+        assert Version("1.5.0") in constraints["zigpy_znp"]
+        assert Version("2.5.0") not in constraints["zigpy_znp"]
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_parse_constraints_bare_package_matches_any_version():
+    assert _run(
+        """
+        from packaging.version import Version
+        home = make_home("bellows\\n")
+        constraints = ph.parse_constraints(home)
+        assert Version("0.0.1") in constraints["bellows"]
+        print("ok")
+        """
+    ) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# check_requirements
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_true_when_all_satisfied():
+    assert _run(
+        """
+        home = make_home("\\n".join([
+            "zigpy==2.1.0",
+            "bellows>=1.0.0",
+        ]))
+        fake_versions({"zigpy": "2.1.0", "bellows": "1.2.0"})
+        assert ph.check_requirements(home) is True
+        assert not ERRORS, ERRORS
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_requirements_false_on_version_mismatch():
+    assert _run(
+        """
+        home = make_home("zigpy==2.1.0\\n")
+        fake_versions({"zigpy": "1.0.0"})
+        assert ph.check_requirements(home) is False
+        assert any("does not satisfy" in e for e in ERRORS), ERRORS
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_requirements_false_when_package_not_installed():
+    assert _run(
+        """
+        home = make_home("zigpy==2.1.0\\n")
+        fake_missing_package()
+        assert ph.check_requirements(home) is False
+        assert any("not installed" in e for e in ERRORS), ERRORS
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_requirements_false_on_invalid_constraint():
+    assert _run(
+        """
+        home = make_home("zigpy~1.0\\n")
+        fake_versions({"zigpy": "2.1.0"})
+        assert ph.check_requirements(home) is False
+        assert any("Invalid version constraint" in e for e in ERRORS), ERRORS
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_requirements_ignores_comments_and_blank_lines():
+    assert _run(
+        """
+        home = make_home("\\n".join([
+            "# top comment",
+            "",
+            "zigpy==2.1.0  # inline comment",
+            "",
+        ]))
+        fake_versions({"zigpy": "2.1.0"})
+        assert ph.check_requirements(home) is True
+        print("ok")
+        """
+    ) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# check_python_modules_version
+# ---------------------------------------------------------------------------
+
+def test_check_python_modules_version_skips_when_internet_access_enabled():
+    assert _run(
+        """
+        self = types.SimpleNamespace(
+            pluginconf=types.SimpleNamespace(pluginConf={"internetAccess": True}),
+            pluginParameters={},
+            log=types.SimpleNamespace(logging=lambda *a, **k: LOGS.append(a)),
+        )
+        assert ph.check_python_modules_version(self) is True
+        assert LOGS == []
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_python_modules_version_true_when_compatible():
+    assert _run(
+        """
+        home = make_home("zigpy==2.1.0\\n")
+        fake_versions({"zigpy": "2.1.0"})
+        self = make_self(home)
+        assert ph.check_python_modules_version(self) is True
+        assert LOGS == []
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_check_python_modules_version_false_when_incompatible():
+    assert _run(
+        """
+        home = make_home("zigpy==2.1.0\\n")
+        fake_versions({"zigpy": "1.0.0"})
+        self = make_self(home)
+        assert ph.check_python_modules_version(self) is False
+        assert any("not compatible" in str(entry) for entry in LOGS), LOGS
+        print("ok")
+        """
+    ) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# list_all_modules_loaded
+# ---------------------------------------------------------------------------
+
+def test_list_all_modules_loaded_runs_and_logs():
+    assert _run(
+        """
+        self = types.SimpleNamespace(log=types.SimpleNamespace(logging=lambda *a, **k: LOGS.append(a)))
+        ph.list_all_modules_loaded(self)
+        assert len(LOGS) >= 2
+        print("ok")
+        """
+    ) == "ok"

--- a/tests/Modules/test_pluginHelpers.py
+++ b/tests/Modules/test_pluginHelpers.py
@@ -115,7 +115,7 @@ def test_all_symbols_imported_by_plugin_are_exported():
 # parse_constraints
 # ---------------------------------------------------------------------------
 
-def test_parse_constraints_keeps_only_tracked_modules():
+def test_parse_constraints_returns_every_entry_by_default():
     assert _run(
         """
         home = make_home("\\n".join([
@@ -127,7 +127,22 @@ def test_parse_constraints_keeps_only_tracked_modules():
             "",
         ]))
         constraints = ph.parse_constraints(home)
-        assert set(constraints) == {"zigpy", "zigpy_znp", "bellows"}, constraints
+        assert set(constraints) == {"zigpy", "zigpy_znp", "unrelated-package", "bellows"}, constraints
+        print("ok")
+        """
+    ) == "ok"
+
+
+def test_parse_constraints_filters_to_given_packages():
+    assert _run(
+        """
+        home = make_home("\\n".join([
+            "zigpy==2.1.0",
+            "unrelated-package==9.9.9",
+            "bellows~=1.0",
+        ]))
+        constraints = ph.parse_constraints(home, ph.PYTHON_MODULES)
+        assert set(constraints) == {"zigpy", "bellows"}, constraints
         print("ok")
         """
     ) == "ok"


### PR DESCRIPTION
  ## Summary

  `check_requirements()` / `parse_constraints()` (`Modules/pluginHelpers.py`) used a
  hand-rolled `==` / `>=` / `<=` string parser to validate the Python modules listed in
  `constraints.txt` against what's actually installed. That parser couldn't evaluate
  combined ranges (`pyserial>=3.5,<4.0`) or `~=` pins, and its return-value contract
  (`True` meant "a problem was found") was easy to get backwards at the call site.

  This PR rewrites both functions on top of `packaging.specifiers.SpecifierSet` /
  `packaging.version.Version`, fixes the fallout from an in-progress version of this
  rewrite that would have broken the plugin on next startup, and dedups the
  constraints.txt parsing that `check_requirements()` and `check_python_modules_version()`
  each did independently.

  ## What changed

  - **`parse_constraints(home_folder, packages=None)`**: the single reader of
    `constraints.txt`, returning `{package: SpecifierSet}` built from the real PEP 440
    grammar instead of manual `==`/`>=`/`<=` string splitting. Returns every entry in the
    file by default, or only the given `packages` subset when passed.
  - **`check_requirements(home_folder)`**: now calls `parse_constraints()` instead of
    re-implementing the read/parse loop, then checks every entry against the installed
    distribution version via `SpecifierSet.__contains__`, honoring any valid PEP 440
    constraint (ranges, `~=`, comments, blank lines). **Return value is now `True` =
    requirements satisfied** (previously `True` = problem found).
  - **`check_python_modules_version(self)`**: now calls `parse_constraints(home, PYTHON_MODULES)`
    to get the same zigpy-family-only subset it relied on when that filtering used to be
    hardcoded into `parse_constraints()`.
  - **`plugin.py` (`onStart`)**: updated the call site to match the new `check_requirements()`
    contract — `if not check_requirements(...): self.onStop()`. The in-progress version
    being reviewed had *not* updated this, so it would have called `onStop()` when
    everything was fine and kept running when modules were actually incompatible.
  - **Restored `check_python_modules_version()` and `list_all_modules_loaded()`**: an
    in-progress diff had deleted both while `plugin.py` still imports them
    (`start_zigbee_transport`, `_start_zigpy_backend`, `_start_native_zigate`, `onStop`'s
    `ListImportedModules` debug dump) — that's an `ImportError` at plugin load, i.e. the
    plugin would fail to start entirely.
  - **Removed `except importlib.metadata.MetadataError`** in `check_requirements()`:
    that exception class does not exist in the stdlib (only `PackageNotFoundError` does).
    Any error other than "package not installed" — e.g. an invalid constraint string —
    crashed with an unhandled `AttributeError` while Python evaluated that `except`
    clause, instead of logging and returning `False`. Caught by the new test suite.
  - **`requirements.txt` / `constraints.txt`**: declared `packaging` as a direct
    dependency since `pluginHelpers.py` now imports it directly — previously
    it was only available because some other dependency pulled it in transitively.
  - Added docstrings throughout `Modules/pluginHelpers.py` (module + every function).

  ## Data flow

  constraints.txt
        │
        ▼
  parse_constraints()
     /
    ▼              ▼
  check_requirements()   check_python_modules_version()
        │                        │
        ▼                        ▼
    SpecifierSet  ─────────►  Version

  ## Tests

  Added `tests/Modules/test_pluginHelpers.py` (14 cases): `parse_constraints`,
  `check_requirements`, `check_python_modules_version`, `list_all_modules_loaded`, plus a
  regression guard asserting every symbol `plugin.py` imports from `Modules.pluginHelpers`
  is present and callable (guards against the `ImportError` above).

  `Modules.pluginHelpers` imports the real `Modules.tools` / `Modules.domoticzAbstractLayer`
  chain, which conflicts with the session-wide `Modules.*` stubs in `tests/conftest.py`.
  Following the pattern already established in
  `tests/Classes/test_scan_classes_deviceconf.py`, these tests run in a subprocess against
  the real module chain, with only `DomoticzEx` faked.

  tests/Modules/test_pluginHelpers.py ..............                     [100%]
  14 passed

  Full suite: `1376 passed, 4 skipped` (no regressions). `flake8` (`E9,F63,F7,F82`): clean.

  ## Test plan

  - [x] Run `pytest .` and `flake8 . --select=E9,F63,F7,F82` on this branch
  - [ ] Verify plugin startup logs `Z4D checks the Python modules requirements` and
        completes normally with a compliant environment
  - [ ] Verify plugin refuses to start (logs the specific unmet constraint, calls
        `onStop()`) when a `constraints.txt` entry is deliberately violated (e.g. force
        install a mismatched `zigpy` version)
  - [ ] Verify `ListImportedModules` debug option still dumps the module list on `onStop()`