### PR TITLE
disabling check of Zigate DNS TXT record

### DIFF
--- a/Modules/checkingUpdate.py
+++ b/Modules/checkingUpdate.py
@@ -182,11 +182,12 @@ def _run_version_check(self, zigbee_communication, branch, zigate_model):
             )
             self.pluginParameters["PluginUpdate"] = True
 
-        if is_zigate_firmware_available(
-            self, self.FirmwareMajorVersion, self.FirmwareVersion, firm_major, firm_minor
-        ):
-            self.log.logging("Plugin", "Status", "Z4D finds a newer Zigate Firmware version")
-            self.pluginParameters["FirmwareUpdate"] = True
+        # Not support provided on zigate. Disabling the check
+        #if is_zigate_firmware_available(
+        #    self, self.FirmwareMajorVersion, self.FirmwareVersion, firm_major, firm_minor
+        #):
+        #    self.log.logging("Plugin", "Status", "Z4D finds a newer Zigate Firmware version")
+        #    self.pluginParameters["FirmwareUpdate"] = True
 
     except Exception as e:
         self.log.logging("Plugin", "Error", "Version check failed: %s" % e)


### PR DESCRIPTION
Zigate is not supported anymore.

Zigate firmware available DNS record has been removed.

Disabling the check