### PR TITLE
Log unrecognized widget Type instead of silently dropping it

### DIFF
--- a/Modules/domoCreate.py
+++ b/Modules/domoCreate.py
@@ -504,11 +504,22 @@ def CreateDomoDevice(self, Devices, NWKID):
                 create_xcube_widgets(self, Devices, NWKID, DeviceID_IEEE, Ep, t)
                 break
 
-            if create_native_widget( self, Devices, NWKID, DeviceID_IEEE, Ep, t):
+            native_result = create_native_widget( self, Devices, NWKID, DeviceID_IEEE, Ep, t)
+            if native_result:
                 continue
 
-            if create_switch_selector_widget( self, Devices, NWKID, DeviceID_IEEE, Ep, t):
+            selector_result = create_switch_selector_widget( self, Devices, NWKID, DeviceID_IEEE, Ep, t)
+            if selector_result:
                 continue
+
+            if native_result is False and selector_result is False:
+                # Neither helper recognized this Type at all (as opposed to recognizing it and
+                # failing to create the widget, which is already logged as an Error above).
+                self.log.logging(
+                    "WidgetCreation", "Error",
+                    "CreateDomoDevice - Unrecognized widget Type '%s' for %s Ep: %s; no widget created. "
+                    "Check device configuration Type spelling against known widget types." % (t, DeviceID_IEEE, Ep),
+                    NWKID)
 
 
     # for Ep


### PR DESCRIPTION
## Summary

`CreateDomoDevice`'s per-`Type` loop tried `create_native_widget()` then
`create_switch_selector_widget()` and simply moved on to the next `Type`
token if both returned falsy. A `Type` token unrecognized by either
helper (e.g. a stale `"WaterCount"` instead of `"WaterCounter"` coming
from device configuration data) was dropped with **zero logging** — no
widget was created and there was no diagnostic trail explaining why.

This surfaced on a real device (`SWV-ZFE`, WaterCount/Switch type):
recreating widgets silently skipped the WaterCounter widget while the
Switch widget was created/reused normally, with no error anywhere in
the logs.

## Change

`Modules/domoCreate.py`'s `CreateDomoDevice` loop now distinguishes:
- a `Type` recognized by a helper but failing to create (already logged
  as an `Error` by the helper itself) — unchanged behavior, and
- a `Type` recognized by **neither** helper (the true silent-drop case)
  — now logs a `WidgetCreation`/`Error` naming the device, endpoint, and
  the unrecognized `Type` string.

The deeper root cause (a stale `"WaterCount"` token in that device's
model configuration, external to this repo — `z4d-certified-devices`
or a `Local-Devices` override) is not fixed here; this PR is
defense-in-depth so any future mismatch is diagnosable instead of
silent.

## Test plan
- [x] `pytest .` — 1386 passed, 0 failed, 1 skipped
- [x] `flake8 . --select=E9,F63,F7,F82` — clean
- [ ] Manual: recreate widgets for a device with a deliberately misspelled `Type` token and confirm the new Error log line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnMe3z8EiyWVuWmpWfKgCh