### PR TITLE
Add Sonoff SWV-ZFE/ZFU manual irrigation, alarm and flow-unit Params

### DIFF
--- a/DevicesModules/custom_sonoff.py
+++ b/DevicesModules/custom_sonoff.py
@@ -24,6 +24,7 @@ The module enables:
 - Configuring temperature and humidity thresholds
 - Handling real-time irrigation parameters (duration, volume)
 - Auto-shutdown of valves on water shortage
+- SWV-ZFE/ZFU manual irrigation session defaults, valve alarms and flow unit
 - Adjusting radio power modes (e.g., Turbo Mode)
 - Setting temperature unit (Celsius/Fahrenheit)
 - Performing temperature calibration
@@ -67,6 +68,21 @@ SONOFF_IRRIGATION_END_TIME = "500e"
 SONOFF_DAILY_IRRIGATION_VOLUME = "500F"
 SONOFF_VALVE_WORK_STATE = "5010"
 SONOFF_WATER_CLOSE_VALVE_TIMEOUT_ATTRIBUTE = "5011"
+
+# Sonoff Smart Valve - SWV-ZFE / SWV-ZFU models (fc11 private attributes, see
+# zigbee-herdsman-converters src/devices/sonoff.ts "SWV-ZFE")
+SONOFF_SWV_MANUAL_DEFAULT_SETTINGS_ATTRIBUTE = "501d"   # ARRAY(uint8)[12]
+SONOFF_SWV_VALVE_ALARM_SETTINGS_ATTRIBUTE = "5020"      # ARRAY(uint8)[4]
+SONOFF_SWV_UNIT_OF_WATER_FLOW_ATTRIBUTE = "5021"        # uint8
+ZCL_ARRAY_DATA_TYPE = "48"
+ZCL_UINT8_DATA_TYPE = "20"
+
+SONOFF_SWV_MAX_IRRIGATION_MINUTES = 719
+SONOFF_SWV_IRRIGATION_MODE = {"duration": 0x00, "capacity": 0x01}
+# 0x501d amount unit byte (legacy mapping, valid on every firmware): 0 = US gallon, 1 = liter
+SONOFF_SWV_AMOUNT_UNIT = {"us_gallon": 0x00, "liter": 0x01}
+# 0x5021 unit of water flow (firmware >= 1.1.0): 0 = liter, 1 = US gallon, 2 = imperial gallon
+SONOFF_SWV_WATER_FLOW_UNIT = {"liter": 0x00, "us_gallon": 0x01, "imperial_gallon": 0x02}
 
 # Sonoff InchingController - ZBMicro model
 SONOFF_RADIO_POWER_TURBO_MODE = "0012"
@@ -128,6 +144,92 @@ def auto_close_when_water_shortage(self, nwkid, value):
     write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "00", SONOFF_WATER_CLOSE_VALVE_TIMEOUT_ATTRIBUTE, "21", water_close_valve_timeout, ackIsDisabled=False)
 
 
+def _zcl_uint8_array(elements):
+    """ Encode a ZCL ARRAY (0x48) of uint8 as hex: element type, count (uint16 LE), elements """
+    return ZCL_UINT8_DATA_TYPE + len(elements).to_bytes(2, "little").hex() + bytes(elements).hex()
+
+
+def _param_int(self, nwkid, param, default, minimum, maximum):
+    value = get_device_config_param(self, nwkid, param)
+    if value is None:
+        return default
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        self.log.logging("Sonoff", "Error", "%s invalid value %s, expected an integer" % (param, value), nwkid)
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _param_choice(self, nwkid, param, choices, default):
+    value = get_device_config_param(self, nwkid, param)
+    if value is None:
+        return default
+    if value not in choices:
+        self.log.logging("Sonoff", "Error", "%s invalid value %s, expected one of %s" % (param, value, sorted(choices)), nwkid)
+        return default
+    return choices[value]
+
+
+def sonoff_swv_manual_default_settings(self, nwkid, value):
+    """ SWV-ZFE/ZFU: settings applied to a manual 'On' (single irrigation session).
+
+    The valve always closes by itself at the end of the session; the factory default is 2 minutes.
+    All SONOFF_SWV_MANUAL_* params are folded into the single 0x501d array, so any of them triggers a full write.
+    Layout (big endian): mode, total duration, irrigation duration, interval, amount unit, amount, fail-safe timeout.
+    """
+    self.log.logging("Sonoff", "Debug", "sonoff_swv_manual_default_settings - Nwkid: %s value: %s" % (nwkid, value), nwkid)
+
+    duration = _param_int(self, nwkid, "SONOFF_SWV_MANUAL_IRRIGATION_DURATION", 2, 1, SONOFF_SWV_MAX_IRRIGATION_MINUTES)
+    mode = _param_choice(self, nwkid, "SONOFF_SWV_MANUAL_IRRIGATION_MODE", SONOFF_SWV_IRRIGATION_MODE, SONOFF_SWV_IRRIGATION_MODE["duration"])
+    amount_unit = _param_choice(self, nwkid, "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT_UNIT", SONOFF_SWV_AMOUNT_UNIT, SONOFF_SWV_AMOUNT_UNIT["liter"])
+    amount = _param_int(self, nwkid, "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT", 0, 0, 10000)
+    # Safety timeout mostly matters in capacity mode; default it to the duration so a session can never run longer than requested
+    fail_safe = _param_int(self, nwkid, "SONOFF_SWV_MANUAL_FAIL_SAFE", duration, 0, SONOFF_SWV_MAX_IRRIGATION_MINUTES)
+    interval = 10  # fixed upstream
+
+    elements = (
+        [mode]
+        + list(duration.to_bytes(2, "big"))
+        + list(duration.to_bytes(2, "big"))
+        + list(interval.to_bytes(2, "big"))
+        + [amount_unit]
+        + list(amount.to_bytes(2, "big"))
+        + list(fail_safe.to_bytes(2, "big"))
+    )
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_SWV_MANUAL_DEFAULT_SETTINGS_ATTRIBUTE, ZCL_ARRAY_DATA_TYPE, _zcl_uint8_array(elements), ackIsDisabled=False)
+
+
+def sonoff_swv_valve_alarm_settings(self, nwkid, value):
+    """ SWV-ZFE/ZFU: water shortage / leak alarms and auto-close on shortage (0x5020).
+
+    All SONOFF_SWV_ALARM_* params are folded into the single 0x5020 array, so any of them triggers a full write.
+    """
+    self.log.logging("Sonoff", "Debug", "sonoff_swv_valve_alarm_settings - Nwkid: %s value: %s" % (nwkid, value), nwkid)
+
+    enable_bits = 0
+    if _param_int(self, nwkid, "SONOFF_SWV_ALARM_WATER_SHORTAGE", 0, 0, 1):
+        enable_bits |= 0b00001
+    if _param_int(self, nwkid, "SONOFF_SWV_ALARM_WATER_LEAK", 0, 0, 1):
+        enable_bits |= 0b00010
+    if _param_int(self, nwkid, "SONOFF_SWV_WATER_SHORTAGE_AUTO_CLOSE", 0, 0, 1):
+        enable_bits |= 0b01000
+    shortage_duration = _param_int(self, nwkid, "SONOFF_SWV_ALARM_WATER_SHORTAGE_DURATION", 5, 1, 10)
+    leak_duration = _param_int(self, nwkid, "SONOFF_SWV_ALARM_WATER_LEAK_DURATION", 1, 1, 3)
+
+    elements = [enable_bits, shortage_duration, leak_duration, 0x00]
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_SWV_VALVE_ALARM_SETTINGS_ATTRIBUTE, ZCL_ARRAY_DATA_TYPE, _zcl_uint8_array(elements), ackIsDisabled=False)
+
+
+def sonoff_swv_water_flow_unit(self, nwkid, unit):
+    """ SWV-ZFE/ZFU: unit used by the flow-meter attributes (0x5021, firmware >= 1.1.0) """
+    if unit not in SONOFF_SWV_WATER_FLOW_UNIT:
+        self.log.logging("Sonoff", "Error", "SONOFF_SWV_WATER_FLOW_UNIT invalid value %s, expected one of %s" % (unit, sorted(SONOFF_SWV_WATER_FLOW_UNIT)), nwkid)
+        return
+    self.log.logging("Sonoff", "Debug", "sonoff_swv_water_flow_unit - Nwkid: %s unit: %s" % (nwkid, unit), nwkid)
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_SWV_UNIT_OF_WATER_FLOW_ATTRIBUTE, ZCL_UINT8_DATA_TYPE, "%02x" % SONOFF_SWV_WATER_FLOW_UNIT[unit], ackIsDisabled=False)
+
+
 def zbmicro_radio_power_turbo_mode(self, nwkid, mode):
     """ Enable/disable Radio Power Turbo Mode """
     RADIO_POWER_MODE = {
@@ -173,6 +275,18 @@ SONOFF_DEVICE_PARAMETERS = {
     "SONOFF_REALTIME_IRRIGATION_VOLUME": sonoff_realtime_irrigation_volume,
     "SONOFF_DAILY_IRRIGATION_VOLUME": sonoff_realtime_irrigation_daily_volume,
     "SONOFF_SWV_WATER_CLOSE_VALVE_TIMEOUT": auto_close_when_water_shortage,
+    "SONOFF_CHILD_LOCK": sonoff_child_lock,
+    "SONOFF_SWV_MANUAL_IRRIGATION_DURATION": sonoff_swv_manual_default_settings,
+    "SONOFF_SWV_MANUAL_IRRIGATION_MODE": sonoff_swv_manual_default_settings,
+    "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT_UNIT": sonoff_swv_manual_default_settings,
+    "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT": sonoff_swv_manual_default_settings,
+    "SONOFF_SWV_MANUAL_FAIL_SAFE": sonoff_swv_manual_default_settings,
+    "SONOFF_SWV_ALARM_WATER_SHORTAGE": sonoff_swv_valve_alarm_settings,
+    "SONOFF_SWV_ALARM_WATER_LEAK": sonoff_swv_valve_alarm_settings,
+    "SONOFF_SWV_WATER_SHORTAGE_AUTO_CLOSE": sonoff_swv_valve_alarm_settings,
+    "SONOFF_SWV_ALARM_WATER_SHORTAGE_DURATION": sonoff_swv_valve_alarm_settings,
+    "SONOFF_SWV_ALARM_WATER_LEAK_DURATION": sonoff_swv_valve_alarm_settings,
+    "SONOFF_SWV_WATER_FLOW_UNIT": sonoff_swv_water_flow_unit,
     "SONOFF_ZBMICRO_RADIO_POWER_TURBO_MODE": zbmicro_radio_power_turbo_mode,
     "SONOFF_TEMP_CALIBRATION": sonoff_temperature_calibration,
     "SONOFF_TEMP_UNIT": sonoff_temperature_unit

--- a/tests/DevicesModules/test_custom_sonoff_swv_zfe.py
+++ b/tests/DevicesModules/test_custom_sonoff_swv_zfe.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for the Sonoff SWV-ZFE / SWV-ZFU Param handlers in
+DevicesModules.custom_sonoff.
+
+On these valves a plain On starts a single irrigation session whose length is
+the fc11 0x501d "manualDefaultSettings" array (factory default: 2 minutes),
+after which the valve closes by itself. The array layout and the 0x5020 /
+0x5021 encodings mirror zigbee-herdsman-converters (src/devices/sonoff.ts).
+"""
+
+import os
+import sys
+import types
+import importlib
+
+import pytest
+from unittest.mock import MagicMock
+
+
+def _ensure_stub(name, **attrs):
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    for k, v in attrs.items():
+        if not hasattr(mod, k):
+            setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def sonoff_module():
+    _ensure_stub("Modules.basicOutputs", write_attribute=MagicMock(name="write_attribute"))
+    _ensure_stub("Modules.tools", get_device_config_param=MagicMock(name="get_device_config_param", return_value=None))
+    _ensure_stub("Modules.zigateConsts", ZIGATE_EP="01")
+
+    # DevicesModules/__init__.py imports every custom_* module (and their real
+    # plugin dependencies); register a bare package pointing at the real
+    # directory so only custom_sonoff is loaded.
+    injected_pkg = "DevicesModules" not in sys.modules
+    if injected_pkg:
+        pkg = types.ModuleType("DevicesModules")
+        pkg.__path__ = [os.path.join(os.path.dirname(__file__), "..", "..", "DevicesModules")]
+        sys.modules["DevicesModules"] = pkg
+
+    sys.modules.pop("DevicesModules.custom_sonoff", None)
+    mod = importlib.import_module("DevicesModules.custom_sonoff")
+    yield mod
+    sys.modules.pop("DevicesModules.custom_sonoff", None)
+    if injected_pkg:
+        sys.modules.pop("DevicesModules", None)
+
+
+@pytest.fixture
+def plugin(sonoff_module):
+    self = MagicMock(name="plugin")
+    self.log.logging = MagicMock(name="logging")
+    sonoff_module.write_attribute.reset_mock()
+    return self
+
+
+def _use_params(sonoff_module, params):
+    sonoff_module.get_device_config_param.side_effect = lambda self, nwkid, key: params.get(key)
+
+
+def _written(sonoff_module):
+    assert sonoff_module.write_attribute.call_count == 1
+    args = sonoff_module.write_attribute.call_args.args
+    # self, key, EPin, EPout, clusterID, manuf_id, manuf_spec, attribute, data_type, data
+    return {"cluster": args[4], "manuf_id": args[5], "manuf_spec": args[6], "attribute": args[7], "data_type": args[8], "data": args[9]}
+
+
+# ─── 0x501d manual default settings ───────────────────────────────────────────
+
+def test_manual_default_settings_only_duration(sonoff_module, plugin):
+    _use_params(sonoff_module, {"SONOFF_SWV_MANUAL_IRRIGATION_DURATION": 719})
+
+    sonoff_module.sonoff_swv_manual_default_settings(plugin, "1234", 719)
+
+    w = _written(sonoff_module)
+    assert (w["cluster"], w["manuf_id"], w["manuf_spec"], w["attribute"], w["data_type"]) == ("fc11", "1286", "01", "501d", "48")
+    # elementType uint8, 12 elements (LE count), then: mode=duration, total=719, duration=719,
+    # interval=10, unit=liter, amount=0, fail_safe defaults to duration (all big endian)
+    assert w["data"] == "20" + "0c00" + "00" + "02cf" + "02cf" + "000a" + "01" + "0000" + "02cf"
+
+
+def test_manual_default_settings_capacity_mode(sonoff_module, plugin):
+    _use_params(sonoff_module, {
+        "SONOFF_SWV_MANUAL_IRRIGATION_DURATION": 30,
+        "SONOFF_SWV_MANUAL_IRRIGATION_MODE": "capacity",
+        "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT_UNIT": "us_gallon",
+        "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT": 100,
+        "SONOFF_SWV_MANUAL_FAIL_SAFE": 45,
+    })
+
+    sonoff_module.sonoff_swv_manual_default_settings(plugin, "1234", "capacity")
+
+    w = _written(sonoff_module)
+    assert w["data"] == "20" + "0c00" + "01" + "001e" + "001e" + "000a" + "00" + "0064" + "002d"
+
+
+def test_manual_default_settings_clamps_and_rejects_bad_values(sonoff_module, plugin):
+    _use_params(sonoff_module, {
+        "SONOFF_SWV_MANUAL_IRRIGATION_DURATION": 5000,       # > 719, clamped
+        "SONOFF_SWV_MANUAL_IRRIGATION_MODE": "bogus",       # rejected -> duration
+        "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT": "abc",       # rejected -> 0
+    })
+
+    sonoff_module.sonoff_swv_manual_default_settings(plugin, "1234", 5000)
+
+    w = _written(sonoff_module)
+    assert w["data"] == "20" + "0c00" + "00" + "02cf" + "02cf" + "000a" + "01" + "0000" + "02cf"
+    error_logs = [c for c in plugin.log.logging.call_args_list if c.args[1] == "Error"]
+    assert len(error_logs) == 2
+
+
+# ─── 0x5020 valve alarm settings ──────────────────────────────────────────────
+
+def test_valve_alarm_settings_defaults(sonoff_module, plugin):
+    _use_params(sonoff_module, {"SONOFF_SWV_ALARM_WATER_LEAK": 0})
+
+    sonoff_module.sonoff_swv_valve_alarm_settings(plugin, "1234", 0)
+
+    w = _written(sonoff_module)
+    assert (w["attribute"], w["data_type"]) == ("5020", "48")
+    # no alarms, shortage duration 5 min, leak duration 1 min, reserved 0
+    assert w["data"] == "20" + "0400" + "00" + "05" + "01" + "00"
+
+
+def test_valve_alarm_settings_all_enabled(sonoff_module, plugin):
+    _use_params(sonoff_module, {
+        "SONOFF_SWV_ALARM_WATER_SHORTAGE": 1,
+        "SONOFF_SWV_ALARM_WATER_LEAK": 1,
+        "SONOFF_SWV_WATER_SHORTAGE_AUTO_CLOSE": 1,
+        "SONOFF_SWV_ALARM_WATER_SHORTAGE_DURATION": 10,
+        "SONOFF_SWV_ALARM_WATER_LEAK_DURATION": 3,
+    })
+
+    sonoff_module.sonoff_swv_valve_alarm_settings(plugin, "1234", 1)
+
+    w = _written(sonoff_module)
+    assert w["data"] == "20" + "0400" + "0b" + "0a" + "03" + "00"
+
+
+# ─── 0x5021 unit of water flow ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("unit,expected", [("liter", "00"), ("us_gallon", "01"), ("imperial_gallon", "02")])
+def test_water_flow_unit(sonoff_module, plugin, unit, expected):
+    sonoff_module.sonoff_swv_water_flow_unit(plugin, "1234", unit)
+
+    w = _written(sonoff_module)
+    assert (w["attribute"], w["data_type"], w["data"]) == ("5021", "20", expected)
+
+
+def test_water_flow_unit_rejects_unknown(sonoff_module, plugin):
+    sonoff_module.sonoff_swv_water_flow_unit(plugin, "1234", "pint")
+
+    assert sonoff_module.write_attribute.call_count == 0
+
+
+# ─── registry ─────────────────────────────────────────────────────────────────
+
+def test_params_are_registered(sonoff_module):
+    reg = sonoff_module.SONOFF_DEVICE_PARAMETERS
+    for key in ("SONOFF_SWV_MANUAL_IRRIGATION_DURATION", "SONOFF_SWV_MANUAL_IRRIGATION_MODE",
+                "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT_UNIT", "SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT",
+                "SONOFF_SWV_MANUAL_FAIL_SAFE"):
+        assert reg[key] is sonoff_module.sonoff_swv_manual_default_settings
+    for key in ("SONOFF_SWV_ALARM_WATER_SHORTAGE", "SONOFF_SWV_ALARM_WATER_LEAK", "SONOFF_SWV_WATER_SHORTAGE_AUTO_CLOSE",
+                "SONOFF_SWV_ALARM_WATER_SHORTAGE_DURATION", "SONOFF_SWV_ALARM_WATER_LEAK_DURATION"):
+        assert reg[key] is sonoff_module.sonoff_swv_valve_alarm_settings
+    assert reg["SONOFF_SWV_WATER_FLOW_UNIT"] is sonoff_module.sonoff_swv_water_flow_unit
+    assert reg["SONOFF_CHILD_LOCK"] is sonoff_module.sonoff_child_lock


### PR DESCRIPTION
## Summary

On the Sonoff SWV-ZFE/ZFU smart water valve a plain Domoticz **On** does not simply open the valve: the firmware starts a single "manual schedule" whose length is taken from the fc11 `0x501d` *manualDefaultSettings* array. Factory default is 2 minutes, after which the valve closes by itself, and nothing in the device config could change that. This PR exposes that array (and the two other simple writable settings from the upstream zigbee-herdsman-converters definition) as device `Param`s so a Domoticz On behaves as the user expects.

## Changes

`DevicesModules/custom_sonoff.py`

| Param | Attribute | Purpose |
|---|---|---|
| `SONOFF_SWV_MANUAL_IRRIGATION_DURATION` (1–719 min) | `0x501d` | how long a manual On keeps the valve open — the actual fix |
| `SONOFF_SWV_MANUAL_IRRIGATION_MODE` (`duration`\|`capacity`), `SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT` (0–10000), `SONOFF_SWV_MANUAL_IRRIGATION_AMOUNT_UNIT` (`liter`\|`us_gallon`), `SONOFF_SWV_MANUAL_FAIL_SAFE` (0–719 min) | `0x501d` | rest of the same 12-byte array |
| `SONOFF_SWV_ALARM_WATER_SHORTAGE`, `SONOFF_SWV_ALARM_WATER_LEAK`, `SONOFF_SWV_WATER_SHORTAGE_AUTO_CLOSE` (0\|1), `SONOFF_SWV_ALARM_WATER_SHORTAGE_DURATION` (1–10 min), `SONOFF_SWV_ALARM_WATER_LEAK_DURATION` (1–3 min) | `0x5020` | valve alarm settings |
| `SONOFF_SWV_WATER_FLOW_UNIT` (`liter`\|`us_gallon`\|`imperial_gallon`, fw ≥ 1.1.0) | `0x5021` | unit of water flow |
| `SONOFF_CHILD_LOCK` (0\|1) | `0x0000` | alias on the existing child-lock writer |

- Arrays are written as ZCL type `0x48` with a pre-encoded payload (element type `0x20`, LE element count, big-endian elements) exactly as upstream does; `rawaps_write_attribute_req` passes it through untouched.
- Out-of-range values are clamped / rejected with an `Error` log naming the expected range.

`tests/DevicesModules/test_custom_sonoff_swv_zfe.py` (new, 10 tests): byte-exact payloads for both modes, clamping, alarm bit packing, flow-unit validation.

## Companion config

`z4d-certified-devices` `Certified/Sonoff/SWV-ZFE.json` gets `"Param": {"SONOFF_SWV_MANUAL_IRRIGATION_DURATION": 719}` (handled separately). Verified on a live SWV-ZFE: after applying the Param, a `0x501d` read returns `00 02cf 02cf 000a 01 0000 02cf` (719 min, echoed 1:1).

## Testing

- `pytest .` — 1392 passed, 5 skipped
- `flake8 . --select=E9,F63,F7,F82` — clean
- Live: SWV-ZFE (`0x86e6`), EZSP/Bellows backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f4ZeNaJVZXCgFo1G5WKdE
